### PR TITLE
Refactor navigation methods to use click events instead of routerLink

### DIFF
--- a/ui/src/app/components/document-listing/document-listing.component.html
+++ b/ui/src/app/components/document-listing/document-listing.component.html
@@ -36,17 +36,19 @@
         >
           <div
             *ngFor="let item of filteredProjectList"
-            (click)="navigateToEdit(item)"
-            (keydown.enter)="navigateToEdit(item)"
-            (keydown.space)="navigateToEdit(item); $event.preventDefault()"
             class="col-span-1 flex rounded-md shadow-sm relative"
-            role="button"
-            tabindex="0"
           >
             <div
               class="flex flex-1 items-center justify-between truncate rounded-lg border border-gray-200 bg-white hover:bg-secondary-50 transition-colors"
             >
-              <div class="flex-1 truncate p-4 text-sm">
+              <div
+                class="flex-1 truncate p-4 text-sm rounded-lg"
+                (click)="navigateToEdit(item)"
+                (keydown.enter)="navigateToEdit(item)"
+                (keydown.space)="navigateToEdit(item); $event.preventDefault()"
+                role="button"
+                tabindex="0"
+              >
                 <a class="font-semibold text-secondary-500">
                   {{ item.fileName.replace("-base.json", "") }}
                 </a>
@@ -107,14 +109,7 @@
               <div class="absolute top-4 right-4 flex space-x-2">
                 <app-button
                   *ngIf="item.folderName === requirementTypes.PRD"
-                  routerLink="/user-stories/{{ item.id }}"
-                  [state]="{
-                    data: this.appInfo,
-                    id: item.id,
-                    folderName: item?.folderName,
-                    fileName: item?.fileName,
-                    req: item.content,
-                  }"
+                  (click)="navigateToUserStories(item)"
                   buttonContent="Stories"
                   theme="secondary_outline"
                   size="sm"

--- a/ui/src/app/components/document-listing/document-listing.component.ts
+++ b/ui/src/app/components/document-listing/document-listing.component.ts
@@ -8,7 +8,7 @@ import {
   truncateWithEllipsis,
 } from '../../utils/common.utils';
 import { filter, map, switchMap } from 'rxjs/operators';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { IList } from '../../model/interfaces/IList';
 import { RequirementTypeEnum } from '../../model/enum/requirement-type.enum';
 import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
@@ -30,7 +30,6 @@ import { ToasterService } from 'src/app/services/toaster/toaster.service';
     AsyncPipe,
     BadgeComponent,
     ButtonComponent,
-    RouterLink,
     NgIconComponent,
     NgForOf,
     SearchInputComponent,
@@ -148,6 +147,18 @@ export class DocumentListingComponent implements OnInit, OnDestroy, AfterViewIni
     const url = folderName === this.requirementTypes.BP ? '/bp-edit' : '/edit';
     this.router.navigate([url], {
       state: { data: this.appInfo, id, folderName, fileName, req: content },
+    });
+  }
+
+  navigateToUserStories(item: any) {
+    this.router.navigate(['/user-stories', item.id], {
+      state: {
+        data: this.appInfo,
+        id: item.id,
+        folderName: item.folderName,
+        fileName: item.fileName,
+        req: item.content,
+      },
     });
   }
 

--- a/ui/src/app/pages/apps/apps.component.html
+++ b/ui/src/app/pages/apps/apps.component.html
@@ -5,7 +5,7 @@
     >
       <h1 class="text-xl font-semibold leading-6 text-gray-900">Solutions</h1>
       <app-button
-        [routerLink]="'/apps/create'"
+        (click)="navigateToCreate()"
         buttonContent="Create Solution"
         size="sm"
       />
@@ -14,7 +14,7 @@
       <!-- Your content -->
       <div class="px-6 pb-6" *ngIf="apps.length === 0">
         <button
-          routerLink="/apps/create"
+          (click)="navigateToCreate()"
           type="button"
           class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
         >

--- a/ui/src/app/pages/apps/apps.component.ts
+++ b/ui/src/app/pages/apps/apps.component.ts
@@ -43,6 +43,10 @@ export class AppsComponent implements OnInit {
       .then();
   }
 
+  navigateToCreate() {
+    this.route.navigate(['/apps/create']);
+  }
+
   ngOnInit() {
     this.store.dispatch(new AddBreadcrumbs([]));
     this.store.dispatch(new GetProjectListAction());

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -134,14 +134,13 @@
         </div>
 
         <div class="mt-6 flex items-center justify-end gap-x-2">
-          <a routerLink="/apps">
-            <app-button
-              buttonContent="Cancel"
-              [disabled]="loading"
-              size="sm"
-              theme="secondary"
-            />
-          </a>
+          <app-button
+            buttonContent="Cancel"
+            [disabled]="loading"
+            size="sm"
+            theme="secondary"
+            (click)="navigateToDashboard()"
+          />
           <app-button
             buttonContent="Create Solution"
             [disabled]="loading || solutionForm.invalid"

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -5,7 +5,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { CreateProject } from '../../store/projects/projects.actions';
 import { v4 as uuid } from 'uuid';
@@ -41,7 +41,6 @@ import { ToggleComponent } from '../../components/toggle/toggle.component';
     ErrorMessageComponent,
     InputFieldComponent,
     TextareaFieldComponent,
-    RouterLink,
     ToggleComponent,
   ],
 })
@@ -146,6 +145,10 @@ export class CreateSolutionComponent implements OnInit {
     return this.solutionForm.get('cleanSolution')?.value
       ? SOLUTION_CREATION_TOGGLE_MESSAGES.BROWNFIELD_SOLUTION
       : SOLUTION_CREATION_TOGGLE_MESSAGES.GREENFIELD_SOLUTION;
+  }
+
+  navigateToDashboard() {
+    this.router.navigate(['/apps']);
   }
 
   protected readonly FormControl = FormControl;

--- a/ui/src/app/pages/tasks/task-list/task-list.component.html
+++ b/ui/src/app/pages/tasks/task-list/task-list.component.html
@@ -47,17 +47,13 @@
             />
           </ng-container>
 
-          <a
-            routerLink="/task/add/{{ selectedUserStory?.id }}"
-            [state]="{ config }"
-          >
-            <app-button
-              buttonContent="Add New"
-              theme="primary"
-              size="sm"
-              rounded="lg"
-            />
-          </a>
+          <app-button
+            buttonContent="Add New"
+            theme="primary"
+            size="sm"
+            rounded="lg"
+            (click)="navigateToAddTask()"
+          />
         </div>
       </div>
 

--- a/ui/src/app/pages/tasks/task-list/task-list.component.ts
+++ b/ui/src/app/pages/tasks/task-list/task-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngxs/store';
 import {
   EditUserStory,
@@ -41,7 +41,6 @@ import { BehaviorSubject } from 'rxjs';
     NgIf,
     AsyncPipe,
     ButtonComponent,
-    RouterLink,
     NgForOf,
     NgIconComponent,
     ListItemComponent,
@@ -136,6 +135,14 @@ export class TaskListComponent implements OnInit, OnDestroy {
         },
       })
       .then();
+  }
+
+  navigateToAddTask() {
+    this.router.navigate(['task/add', this.selectedUserStory?.id], {
+      state: {
+        config: this.config,
+      },
+    });
   }
 
   addExtraContext() {

--- a/ui/src/app/pages/user-stories/user-stories.component.html
+++ b/ui/src/app/pages/user-stories/user-stories.component.html
@@ -103,20 +103,7 @@
       >
         <div class="absolute top-4 right-4 flex gap-2">
           <app-button
-            routerLink="/task-list/{{ userStory.id }}"
-            [state]="{
-              config: {
-                folderName: navigation.folderName,
-                fileName: navigation.fileName,
-                projectId: navigation.projectId,
-                newFileName,
-                currentProject,
-                i,
-                featureId: userStory.id,
-                featureName: userStory.name,
-                reqId: newFileName.split('-')[0],
-              },
-            }"
+            (click)="navigateToTaskList(userStory, i)"
             buttonContent="View Tasks"
             theme="secondary_outline"
             size="xs"

--- a/ui/src/app/pages/user-stories/user-stories.component.ts
+++ b/ui/src/app/pages/user-stories/user-stories.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { NGXLogger } from 'ngx-logger';
 import { Store } from '@ngxs/store';
 import { UserStoriesState } from '../../store/user-stories/user-stories.state';
@@ -55,7 +55,6 @@ import { BehaviorSubject } from 'rxjs';
   standalone: true,
   imports: [
     ButtonComponent,
-    RouterLink,
     MatMenuModule,
     AsyncPipe,
     NgIf,
@@ -228,6 +227,24 @@ export class UserStoriesComponent implements OnInit {
         },
       })
       .then();
+  }
+
+  navigateToTaskList(userStory: IUserStory, index: number) {
+    this.router.navigate(['/task-list', userStory.id], {
+      state: {
+        config: {
+          folderName: this.navigation.folderName,
+          fileName: this.navigation.fileName,
+          projectId: this.navigation.projectId,
+          newFileName: this.newFileName,
+          currentProject: this.currentProject,
+          i: index,
+          featureId: userStory.id,
+          featureName: userStory.name,
+          reqId: this.newFileName.split('-')[0],
+        },
+      },
+    });
   }
 
   navigateToAppIntegrations() {


### PR DESCRIPTION
### Description

This PR refactors the navigation methods to use `click` events instead of `routerLink`. The change was made to prevent the `app-button` from being focusable twice. Previously, the `routerLink` was causing the button to be focusable both through the link and the button element, leading to accessibility issues. 

### Summary of Changes:

- Replaced `routerLink` with `click` events to resolve the issue of the `app-button` being focusable twice.
