### PR TITLE
feat: Add validation for BP file associations for PRDs and BRDs before deletion

### DIFF
--- a/ui/src/app/constants/app.constants.ts
+++ b/ui/src/app/constants/app.constants.ts
@@ -14,7 +14,6 @@ export const CHAT_TYPES = {
 };
 
 export const BP_FILE_KEYS = {
-  FOLDER_NAME: 'BP',
   BRD_KEY: 'selectedBRDs',
   PRD_KEY: 'selectedPRDs',
 };

--- a/ui/src/app/constants/app.constants.ts
+++ b/ui/src/app/constants/app.constants.ts
@@ -13,9 +13,17 @@ export const CHAT_TYPES = {
   TASK: 'task',
 };
 
+export const BP_FILE_KEYS = {
+  FOLDER_NAME: 'BP',
+  BRD_KEY: 'selectedBRDs',
+  PRD_KEY: 'selectedPRDs',
+};
+
 export const ERROR_MESSAGES = {
   PASSWORD_ERROR: 'Passcode does not match. Please try again.',
-  GENERATE_SUGGESTIONS_FAILED: 'Failed to generate suggestions'
+  GENERATE_SUGGESTIONS_FAILED: 'Failed to generate suggestions',
+  DELETE_ASSOCIATED_ERROR: (reqId: string, bpIds: string[]) =>
+    `Unable to remove ${reqId} because it's linked to the following business processes: ${bpIds.join(', ')}.`,
 };
 
 export const SOLUTION_CREATION_TOGGLE_MESSAGES = {

--- a/ui/src/app/pages/edit-solution/edit-solution.component.ts
+++ b/ui/src/app/pages/edit-solution/edit-solution.component.ts
@@ -40,7 +40,8 @@ import {
   TOASTER_MESSAGES,
 } from '../../constants/app.constants';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
-import { switchMap, take } from 'rxjs';
+import { catchError, switchMap, take } from 'rxjs';
+import { RequirementTypeEnum } from 'src/app/model/enum/requirement-type.enum';
 
 @Component({
   selector: 'app-edit-solution',
@@ -319,7 +320,10 @@ ${chat.assistant}`,
   deleteFile() {
     const reqId = this.fileName.replace(/\-base.json$/, '');
 
-    if (this.folderName === 'PRD' || this.folderName === 'BRD') {
+    if (
+      this.folderName === RequirementTypeEnum.PRD ||
+      this.folderName === RequirementTypeEnum.BRD
+    ) {
       this.store
         .dispatch(new checkBPFileAssociations(this.folderName, this.fileName))
         .pipe(
@@ -328,6 +332,12 @@ ${chat.assistant}`,
               .select(ProjectsState.getBpAssociationStatus)
               .pipe(take(1)),
           ),
+          catchError(() => {
+            this.toastService.showError(
+              TOASTER_MESSAGES.ENTITY.DELETE.FAILURE(this.folderName, reqId),
+            );
+            return [];
+          }),
         )
         .subscribe((res) => {
           if (res.isAssociated) {

--- a/ui/src/app/store/projects/projects.actions.ts
+++ b/ui/src/app/store/projects/projects.actions.ts
@@ -82,3 +82,12 @@ export class UpdateMetadata {
 export class ClearBRDPRDState {
   static readonly type = '[Projects] Clear BRD and PRD State';
 }
+
+export class checkBPFileAssociations {
+  static readonly type = '[Projects] Check File Associations';
+
+  constructor(
+    public folderName: string,
+    public fileName: string,
+  ) {}
+}

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -277,7 +277,9 @@ export class ProjectsState {
         );
         const parsedContent = JSON.parse(content);
         const key =
-          folderName === 'PRD' ? BP_FILE_KEYS.PRD_KEY : BP_FILE_KEYS.BRD_KEY;
+          folderName === RequirementTypeEnum.PRD
+            ? BP_FILE_KEYS.PRD_KEY
+            : BP_FILE_KEYS.BRD_KEY;
         const isReferenced = this.isFileReferenced(
           fileName,
           parsedContent,
@@ -299,12 +301,7 @@ export class ProjectsState {
         fileName,
         error,
       });
-      patchState({
-        bpAssociationStatus: {
-          isAssociated: false,
-          bpIds: [],
-        },
-      });
+      throw error;
     }
   }
 

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -13,6 +13,7 @@ import {
   ArchiveFile,
   UpdateMetadata,
   ClearBRDPRDState,
+  checkBPFileAssociations,
 } from './projects.actions';
 import { AppSystemService } from '../../services/app-system/app-system.service';
 import { NGXLogger } from 'ngx-logger';
@@ -21,6 +22,7 @@ import { Router } from '@angular/router';
 import { IList } from '../../model/interfaces/IList';
 import { firstValueFrom } from 'rxjs';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
+import { BP_FILE_KEYS } from 'src/app/constants/app.constants';
 
 export class ProjectStateModel {
   projects!: IProject[];
@@ -31,6 +33,10 @@ export class ProjectStateModel {
   metadata!: any;
   loadingProjectFiles!: boolean;
   fileExists!: boolean;
+  bpAssociationStatus!: {
+    isAssociated: boolean;
+    bpIds: string[];
+  };
 }
 
 @State<ProjectStateModel>({
@@ -44,6 +50,10 @@ export class ProjectStateModel {
     selectedFileContents: [],
     loadingProjectFiles: false,
     fileExists: false,
+    bpAssociationStatus: {
+      isAssociated: false,
+      bpIds: [],
+    },
   },
 })
 @Injectable()
@@ -94,6 +104,11 @@ export class ProjectsState {
   @Selector()
   static getMetadata(state: ProjectStateModel) {
     return state.metadata;
+  }
+
+  @Selector()
+  static getBpAssociationStatus(state: ProjectStateModel) {
+    return state.bpAssociationStatus;
   }
 
   @Action(GetProjectListAction)
@@ -233,6 +248,75 @@ export class ProjectsState {
       this.logger.error('Failed to fetch project files:', error);
       patchState({ loadingProjectFiles: false });
     }
+  }
+
+  @Action(checkBPFileAssociations)
+  async checkBPFileAssociations(
+    { getState, patchState }: StateContext<ProjectStateModel>,
+    { folderName, fileName }: checkBPFileAssociations,
+  ) {
+    const state = getState();
+    const bpFolder = state.currentProjectFiles.find(
+      (f) => f.name === BP_FILE_KEYS.FOLDER_NAME,
+    );
+
+    if (!bpFolder) {
+      patchState({
+        bpAssociationStatus: { isAssociated: false, bpIds: [] },
+      });
+      return;
+    }
+
+    try {
+      const associatedBpIds: string[] = [];
+
+      for (const file of bpFolder.children) {
+        const content = await this.appSystemService.readFile(
+          `${state.selectedProject}/${BP_FILE_KEYS.FOLDER_NAME}/${file}`,
+        );
+        const parsedContent = JSON.parse(content);
+        const key =
+          folderName === 'PRD' ? BP_FILE_KEYS.PRD_KEY : BP_FILE_KEYS.BRD_KEY;
+        const isReferenced = this.isFileReferenced(
+          fileName,
+          parsedContent,
+          key,
+        );
+
+        if (isReferenced) associatedBpIds.push(file.split('-')[0]);
+      }
+
+      patchState({
+        bpAssociationStatus: {
+          isAssociated: associatedBpIds.length > 0,
+          bpIds: associatedBpIds,
+        },
+      });
+    } catch (error) {
+      this.logger.error('Error checking file associations', {
+        folderName,
+        fileName,
+        error,
+      });
+      patchState({
+        bpAssociationStatus: {
+          isAssociated: false,
+          bpIds: [],
+        },
+      });
+    }
+  }
+
+  private isFileReferenced(
+    fileName: string,
+    parsedContent: any,
+    key: string,
+  ): boolean {
+    return (
+      parsedContent[key]?.some(
+        (entry: { fileName: string }) => entry.fileName === fileName,
+      ) || false
+    );
   }
 
   private generateFiles(

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -23,6 +23,7 @@ import { IList } from '../../model/interfaces/IList';
 import { firstValueFrom } from 'rxjs';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
 import { BP_FILE_KEYS } from 'src/app/constants/app.constants';
+import { RequirementTypeEnum } from 'src/app/model/enum/requirement-type.enum';
 
 export class ProjectStateModel {
   projects!: IProject[];
@@ -257,7 +258,7 @@ export class ProjectsState {
   ) {
     const state = getState();
     const bpFolder = state.currentProjectFiles.find(
-      (f) => f.name === BP_FILE_KEYS.FOLDER_NAME,
+      (f) => f.name === RequirementTypeEnum.BP,
     );
 
     if (!bpFolder) {
@@ -272,7 +273,7 @@ export class ProjectsState {
 
       for (const file of bpFolder.children) {
         const content = await this.appSystemService.readFile(
-          `${state.selectedProject}/${BP_FILE_KEYS.FOLDER_NAME}/${file}`,
+          `${state.selectedProject}/${RequirementTypeEnum.BP}/${file}`,
         );
         const parsedContent = JSON.parse(content);
         const key =


### PR DESCRIPTION
### Description:
This PR implements a restriction on the deletion of PRD (Product Requirement Document) and BRD (Business Requirement Document) files if they are currently in use by a Business Process (BP). The feature ensures that these documents cannot be deleted when associated with an active business process.

### Changes include:
- Added logic to check if PRD or BRD files are associated with any BP before allowing deletion.
- Updated the deletion process to handle these restrictions.
- Enhanced error handling and validation for the deletion process.
- Updated related components to reflect changes in file deletion behavior.

### Screenshot:

![Error Message when Deleting Used PRD/BRD](https://github.com/user-attachments/assets/8a50260b-738e-49c1-bfb8-bee9f744974b)
*Screenshot showing the error when attempting to delete a PRD that is in use by a BP.*