### PR TITLE
refactor: removed default llm provider settings on electron and fetch the default llm provider settings from backend

### DIFF
--- a/backend/api/common_api.py
+++ b/backend/api/common_api.py
@@ -2,6 +2,7 @@ from llm.llm_service import LLMService
 from flask import Blueprint, request, g, jsonify
 from config.exceptions import CustomAppException
 from config.logging_config import logger
+from utils.env_utils import EnvVariables, get_env_variable
 
 common_api = Blueprint('common_api', __name__)
 llMService = LLMService()
@@ -17,6 +18,22 @@ def test():
         raise CustomAppException(f"An error occurred: {str(e)}", status_code=500) from e
     logger.info("Exited <test>")
     return jsonify(response)
+
+@common_api.route("/api/llm-config/defaults", methods=["GET"])
+def get_default_llm_config():
+    logger.info("Entered <get_default_llm_config>")
+    try:
+        default_config = {
+            "provider": get_env_variable(EnvVariables.DEFAULT_API_PROVIDER),
+            "model": get_env_variable(EnvVariables.DEFAULT_MODEL)
+        }
+        logger.info(f"Default LLM configuration: {default_config}")
+        return jsonify(default_config)
+    except Exception as e:
+        logger.error(f"An error occurred while fetching default LLM configuration: {str(e)}")
+        raise CustomAppException("Failed to fetch default LLM configuration", status_code=500) from e
+    finally:
+        logger.info("Exited <get_default_llm_config>")
 
 @common_api.route("/api/model/config-verification", methods=["POST"])
 def verify_provider_config():

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { ElectronService } from './services/electron/electron.service';
 import { AuthService } from './services/auth/auth.service';
 import { Store } from '@ngxs/store';
 import { LLMConfigState } from './store/llm-config/llm-config.state';
+import { VerifyLLMConfig } from './store/llm-config/llm-config.actions';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -52,12 +53,12 @@ export class AppComponent implements OnInit, OnDestroy {
   private initializeLLMConfig() {
     this.logger.debug('Initializing LLM configuration');
     if (this.authService.isAuthenticated()) {
-      this.authService.initializeLLMConfig().subscribe({
-        next: () => this.logger.debug('LLM configuration initialized successfully'),
-        error: (error) => this.logger.error('Error initializing LLM configuration', error)
+      this.store.dispatch(new VerifyLLMConfig()).subscribe({
+        next: () => this.logger.debug('LLM configuration verified successfully'),
+        error: (error) => this.logger.error('Error verifying LLM configuration', error)
       });
     } else {
-      this.logger.debug('User not authenticated, skipping LLM configuration initialization');
+      this.logger.debug('User not authenticated, skipping LLM configuration verification');
     }
   }
 }

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { Store } from '@ngxs/store';
 import { LLMConfigState } from './store/llm-config/llm-config.state';
 import { VerifyLLMConfig } from './store/llm-config/llm-config.actions';
 import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-root',
@@ -20,7 +21,7 @@ export class AppComponent implements OnInit, OnDestroy {
   authService = inject(AuthService);
   store = inject(Store);
 
-  private authSubscription: Subscription | null = null;
+  private subscriptions: Subscription[] = [];
 
   ngOnInit() {
     if (sessionStorage.getItem('serverActive') !== 'true') {
@@ -37,17 +38,17 @@ export class AppComponent implements OnInit, OnDestroy {
 
     this.initializeLLMConfig();
 
-    this.authSubscription = this.authService.isLoggedIn$.subscribe((isLoggedIn) => {
-      if (isLoggedIn) {
+    this.subscriptions.push(
+      this.authService.isLoggedIn$.pipe(
+        filter(isLoggedIn => isLoggedIn)
+      ).subscribe(() => {
         this.initializeLLMConfig();
-      }
-    });
+      })
+    );
   }
 
   ngOnDestroy() {
-    if (this.authSubscription) {
-      this.authSubscription.unsubscribe();
-    }
+    this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 
   private initializeLLMConfig() {

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,17 +1,25 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
 import { NGXLogger } from 'ngx-logger';
 import { Router } from '@angular/router';
 import { ElectronService } from './services/electron/electron.service';
+import { AuthService } from './services/auth/auth.service';
+import { Store } from '@ngxs/store';
+import { LLMConfigState } from './store/llm-config/llm-config.state';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, OnDestroy {
   electronService = inject(ElectronService);
   logger = inject(NGXLogger);
   router = inject(Router);
+  authService = inject(AuthService);
+  store = inject(Store);
+
+  private authSubscription: Subscription | null = null;
 
   ngOnInit() {
     if (sessionStorage.getItem('serverActive') !== 'true') {
@@ -24,6 +32,32 @@ export class AppComponent implements OnInit {
           this.logger.error('Error listening to port', error);
           alert('An error occurred while trying to listen to the port.');
         });
+    }
+
+    this.initializeLLMConfig();
+
+    this.authSubscription = this.authService.isLoggedIn$.subscribe((isLoggedIn) => {
+      if (isLoggedIn) {
+        this.initializeLLMConfig();
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.authSubscription) {
+      this.authSubscription.unsubscribe();
+    }
+  }
+
+  private initializeLLMConfig() {
+    this.logger.debug('Initializing LLM configuration');
+    if (this.authService.isAuthenticated()) {
+      this.authService.initializeLLMConfig().subscribe({
+        next: () => this.logger.debug('LLM configuration initialized successfully'),
+        error: (error) => this.logger.error('Error initializing LLM configuration', error)
+      });
+    } else {
+      this.logger.debug('User not authenticated, skipping LLM configuration initialization');
     }
   }
 }

--- a/ui/src/app/components/llm-settings/llm-settings.component.ts
+++ b/ui/src/app/components/llm-settings/llm-settings.component.ts
@@ -44,20 +44,15 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // Store initial values
-    const config = this.store.selectSnapshot(LLMConfigState.getConfig);
-    this.initialModel = config.model;
-    this.initialProvider = config.provider;
-    
-    // Set form controls
-    this.selectedModel.setValue(this.initialModel);
-    this.selectedProvider.setValue(this.initialProvider);
-    this.hasChanges = false;
-
     this.subscriptions.add(
       this.llmConfig$.subscribe((config) => {
         this.currentLLMConfig = config;
         this.updateFilteredModels(config?.provider);
+        this.selectedModel.setValue(config.model);
+        this.selectedProvider.setValue(config.provider);
+        this.initialModel = config.model;
+        this.initialProvider = config.provider;
+        this.hasChanges = false;
       })
     );
     this.onModelChange();
@@ -69,9 +64,8 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
       this.selectedModel.valueChanges
         .pipe(distinctUntilChanged())
         .subscribe((res) => {
-          // Only update filtered models, don't update store
           this.updateFilteredModels(this.selectedProvider.value);
-          this.errorMessage = ''; // Clear error message on change
+          this.errorMessage = '';
           this.hasChanges = 
             this.selectedModel.value !== this.initialModel || 
             this.selectedProvider.value !== this.initialProvider;
@@ -87,7 +81,7 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
         .subscribe((res) => {
           this.updateFilteredModels(res);
           this.selectedModel.setValue(providerModelMap[res][0]);
-          this.errorMessage = ''; // Clear error message on change
+          this.errorMessage = '';
           this.hasChanges = 
             this.selectedModel.value !== this.initialModel || 
             this.selectedProvider.value !== this.initialProvider;
@@ -101,7 +95,6 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
   }
 
   closeModal() {
-    // Revert to initial values in the store
     this.store.dispatch(
       new SetLLMConfig({
         ...this.currentLLMConfig,
@@ -119,15 +112,14 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
     this.authService.verifyProviderConfig(provider, model).subscribe({
       next: (response) => {
         if (response.status === "success") {
-          // Update store with new values only on successful verification
-          this.store.dispatch(
-            new SetLLMConfig({
-              ...this.currentLLMConfig,
-              model: model,
-              provider: provider,
-            })
-          );
-          this.toasterService.showSuccess('Provider configuration verified successfully');
+          const newConfig = {
+            ...this.currentLLMConfig,
+            model: model,
+            provider: provider,
+          };
+          this.store.dispatch(new SetLLMConfig(newConfig));
+          localStorage.setItem('llmConfig', JSON.stringify(newConfig));
+          this.toasterService.showSuccess('Provider configuration verified and saved successfully');
           this.modalRef.close(true);
         } else {
           this.errorMessage = "Connection Failed! Please verify your model credentials in the backend configuration.";

--- a/ui/src/app/components/llm-settings/llm-settings.component.ts
+++ b/ui/src/app/components/llm-settings/llm-settings.component.ts
@@ -120,7 +120,7 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
           this.store.dispatch(new SetLLMConfig(newConfig)).subscribe(() => {
             this.store.dispatch(new SyncLLMConfig()).subscribe(() => {
               const providerDisplayName = this.availableProviders.find(p => p.key === provider)?.displayName || provider;
-              this.toasterService.showSuccess(`${providerDisplayName} : ${model} is now configured successfully.`);
+              this.toasterService.showSuccess(`${providerDisplayName} : ${model} is configured successfully.`);
               this.modalRef.close(true);
             });
           });

--- a/ui/src/app/components/toaster/toaster.component.html
+++ b/ui/src/app/components/toaster/toaster.component.html
@@ -1,20 +1,17 @@
 <div
-  *ngFor="let toast of toasts"
-  class="fixed bottom-4 right-4 z-50 text-xs"
-  (click)="removeToast(toast.id)"
-  (keydown.enter)="removeToast(toast.id)"
-  (keydown.space)="removeToast(toast.id); $event.preventDefault()"
-  role="button"
-  tabindex="0"
+  *ngIf="toasts.length > 0"
+  class="fixed bottom-4 right-4 z-50 text-xs transition-opacity duration-300 ease-in-out"
+  [ngClass]="{'opacity-100': toasts[0].show, 'opacity-0': !toasts[0].show}"
+  (click)="removeToast(toasts[0].id)"
 >
   <div
     class="w-72 p-4 rounded-lg border-[0.5px]"
     [ngClass]="{
       'bg-success-50 border-success-300 text-success-600':
-        toast.type === 'success',
-      'bg-danger-50 border-danger-300 text-danger-600': toast.type === 'error',
-      'bg-blue-50 border-blue-300 text-blue-600': toast.type === 'info',
-      'bg-warning-50 border-warning-300 text-warning-600': toast.type === 'warning'
+        toasts[0].type === 'success',
+      'bg-danger-50 border-danger-300 text-danger-600': toasts[0].type === 'error',
+      'bg-blue-50 border-blue-300 text-blue-600': toasts[0].type === 'info',
+      'bg-warning-50 border-warning-300 text-warning-600': toasts[0].type === 'warning'
     }"
   >
     <div class="flex items-center overflow-hidden gap-2">
@@ -22,18 +19,18 @@
       <div class="flex items-center justify-center">
         <ng-icon
           [name]="
-            toast.type === 'success'
+            toasts[0].type === 'success'
               ? 'heroCheckCircle'
-              : toast.type === 'error'
+              : toasts[0].type === 'error'
                 ? 'heroExclamationCircle'
-                : toast.type === 'warning'
+                : toasts[0].type === 'warning'
                 ? 'heroExclamationTriangle'
                 : 'heroInformationCircle'
           "
           class="text-lg"
         />
       </div>
-      <div class="w-full break-words" [innerHTML]="toast.message"></div>
+      <div class="w-full break-words" [innerHTML]="toasts[0].message"></div>
     </div>
   </div>
 </div>

--- a/ui/src/app/components/toaster/toaster.component.html
+++ b/ui/src/app/components/toaster/toaster.component.html
@@ -1,36 +1,40 @@
-<div
-  *ngIf="toasts.length > 0"
-  class="fixed bottom-4 right-4 z-50 text-xs transition-opacity duration-300 ease-in-out"
-  [ngClass]="{'opacity-100': toasts[0].show, 'opacity-0': !toasts[0].show}"
-  (click)="removeToast(toasts[0].id)"
->
+<div class="fixed bottom-4 right-4 z-50 flex flex-col-reverse gap-2">
   <div
-    class="w-72 p-4 rounded-lg border-[0.5px]"
-    [ngClass]="{
-      'bg-success-50 border-success-300 text-success-600':
-        toasts[0].type === 'success',
-      'bg-danger-50 border-danger-300 text-danger-600': toasts[0].type === 'error',
-      'bg-blue-50 border-blue-300 text-blue-600': toasts[0].type === 'info',
-      'bg-warning-50 border-warning-300 text-warning-600': toasts[0].type === 'warning'
-    }"
+    *ngFor="let toast of toasts"
+    class="text-xs transition-opacity duration-300 ease-in-out"
+    [ngClass]="{'opacity-100': toast.show, 'opacity-0': !toast.show}"
+    (click)="removeToast(toast.id)"
+    (keydown.enter)="removeToast(toast.id)"
+    (keydown.space)="removeToast(toast.id); $event.preventDefault()"
   >
-    <div class="flex items-center overflow-hidden gap-2">
-      <!-- Display the appropriate icon based on toast type -->
-      <div class="flex items-center justify-center">
-        <ng-icon
-          [name]="
-            toasts[0].type === 'success'
-              ? 'heroCheckCircle'
-              : toasts[0].type === 'error'
-                ? 'heroExclamationCircle'
-                : toasts[0].type === 'warning'
-                ? 'heroExclamationTriangle'
-                : 'heroInformationCircle'
-          "
-          class="text-lg"
-        />
+    <div
+      class="w-72 p-4 rounded-lg border-[0.5px]"
+      [ngClass]="{
+        'bg-success-50 border-success-300 text-success-600':
+          toast.type === 'success',
+        'bg-danger-50 border-danger-300 text-danger-600': toast.type === 'error',
+        'bg-blue-50 border-blue-300 text-blue-600': toast.type === 'info',
+        'bg-warning-50 border-warning-300 text-warning-600': toast.type === 'warning'
+      }"
+    >
+      <div class="flex items-center overflow-hidden gap-2">
+        <!-- Display the appropriate icon based on toast type -->
+        <div class="flex items-center justify-center">
+          <ng-icon
+            [name]="
+              toast.type === 'success'
+                ? 'heroCheckCircle'
+                : toast.type === 'error'
+                  ? 'heroExclamationCircle'
+                  : toast.type === 'warning'
+                  ? 'heroExclamationTriangle'
+                  : 'heroInformationCircle'
+            "
+            class="text-lg"
+          />
+        </div>
+        <div class="w-full break-words" [innerHTML]="toast.message"></div>
       </div>
-      <div class="w-full break-words" [innerHTML]="toasts[0].message"></div>
     </div>
   </div>
 </div>

--- a/ui/src/app/components/toaster/toaster.component.ts
+++ b/ui/src/app/components/toaster/toaster.component.ts
@@ -4,6 +4,7 @@ import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { NgIconComponent } from '@ng-icons/core';
 import { heroCheckCircle, heroExclamationCircle, heroInformationCircle, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
 import { Subscription } from 'rxjs';
+import { DEFAULT_TOAST_DURATION } from 'src/app/constants/toast.constant';
 
 @Component({
   selector: 'app-toaster',
@@ -25,30 +26,29 @@ export class ToasterComponent implements OnInit, OnDestroy {
     private cdr: ChangeDetectorRef,
   ) {}
 
-
   ngOnInit() {
-    this.toastSubscription = this.toasterService.getToasts().subscribe((toast) => {
-      this.addToast(toast);
+    this.toastSubscription = this.toasterService.getToasts().subscribe((newToast) => {
+      this.addToast(newToast);
     });
   }
 
-  addToast(toast: any) {
-    if (!toast.message || toast.message.trim() === '') {
+  addToast(newToast: any) {
+    if (!newToast.message || newToast.message.trim() === '') {
       return;
     }
-    const newToast = { ...toast, show: true };
-    this.toasts = [newToast];
+    const toast = { ...newToast, show: true };
+    this.toasts.push(toast);
     this.cdr.detectChanges();
 
     // Set timeout for auto-removal
-    this.toastTimeouts[newToast.id] = setTimeout(() => {
-      this.removeToast(newToast.id);
-    }, newToast.duration || 5000);
+    this.toastTimeouts[toast.id] = setTimeout(() => {
+      this.removeToast(toast.id);
+    }, newToast.duration);
   }
 
   removeToast(id: number) {
-    const toastIndex = this.toasts.findIndex((t) => t.id === id);
-    if (toastIndex > -1) {
+    const index = this.toasts.findIndex(t => t.id === id);
+    if (index > -1) {
       // Clear the timeout
       if (this.toastTimeouts[id]) {
         clearTimeout(this.toastTimeouts[id]);
@@ -56,17 +56,14 @@ export class ToasterComponent implements OnInit, OnDestroy {
       }
 
       // Start fade-out animation
-      this.toasts[toastIndex].show = false;
+      this.toasts[index].show = false;
       this.cdr.detectChanges();
 
-      // Remove toast from array after animation completes
+      // Remove toast after animation completes
       setTimeout(() => {
-        this.toasts = this.toasts.filter((toast) => toast.id !== id);
-        if (this.toasts.length === 0) {
-          // Ensure the toast container is removed from the DOM
-          this.cdr.detectChanges();
-        }
-      }, 300); // Adjust this value to match your CSS transition duration
+        this.toasts = this.toasts.filter(t => t.id !== id);
+        this.cdr.detectChanges();
+      }, 300);
     }
   }
 

--- a/ui/src/app/components/toaster/toaster.component.ts
+++ b/ui/src/app/components/toaster/toaster.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, OnDestroy } from '@angular/core';
 import { ToasterService } from '../../services/toaster/toaster.service';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { NgIconComponent } from '@ng-icons/core';
 import { heroCheckCircle, heroExclamationCircle, heroInformationCircle, heroExclamationTriangle } from '@ng-icons/heroicons/outline';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-toaster',
@@ -14,26 +15,67 @@ import { heroCheckCircle, heroExclamationCircle, heroInformationCircle, heroExcl
     { provide: 'icons', useValue: { heroCheckCircle, heroExclamationCircle, heroInformationCircle, heroExclamationTriangle } }
   ]
 })
-export class ToasterComponent {
+export class ToasterComponent implements OnInit, OnDestroy {
   toasts: any[] = [];
+  private toastSubscription: Subscription = new Subscription();
+  private toastTimeouts: { [id: number]: any } = {};
 
   constructor(
     private toasterService: ToasterService,
     private cdr: ChangeDetectorRef,
-  ) {
-    this.toasterService.getToasts().subscribe((toast) => {
-      // Clear the previous toast (if any) to ensure only one toast is visible
-      this.toasts = [toast];
-      this.cdr.detectChanges();
-      // Auto-remove the toast after 5 seconds
-      setTimeout(() => {
-        this.removeToast(toast.id);
-        this.cdr.markForCheck();
-      }, 5000); // 5 seconds timeout
+  ) {}
+
+  ngOnInit() {
+    this.toastSubscription = this.toasterService.getToasts().subscribe((toast) => {
+      this.addToast(toast);
     });
   }
 
+  addToast(toast: any) {
+    const newToast = { ...toast, show: true };
+    this.toasts = [newToast];
+    this.cdr.detectChanges();
+
+    // Set timeout for auto-removal
+    this.toastTimeouts[newToast.id] = setTimeout(() => {
+      this.removeToast(newToast.id);
+    }, newToast.duration || 5000);
+  }
+
   removeToast(id: number) {
-    this.toasts = this.toasts.filter((toast) => toast.id !== id);
+    const toastIndex = this.toasts.findIndex((t) => t.id === id);
+    if (toastIndex > -1) {
+      // Clear the timeout
+      if (this.toastTimeouts[id]) {
+        clearTimeout(this.toastTimeouts[id]);
+        delete this.toastTimeouts[id];
+      }
+
+      // Start fade-out animation
+      this.toasts[toastIndex].show = false;
+      this.cdr.detectChanges();
+
+      // Remove toast from array after animation completes
+      setTimeout(() => {
+        this.toasts = this.toasts.filter((toast) => toast.id !== id);
+        if (this.toasts.length === 0) {
+          // Ensure the toast container is removed from the DOM
+          this.cdr.detectChanges();
+        }
+      }, 300); // Adjust this value to match your CSS transition duration
+    }
+  }
+
+  // Add this method to handle manual toast dismissal
+  onToastClick(id: number) {
+    this.removeToast(id);
+  }
+
+  ngOnDestroy() {
+    if (this.toastSubscription) {
+      this.toastSubscription.unsubscribe();
+    }
+    // Clear all timeouts
+    Object.values(this.toastTimeouts).forEach(clearTimeout);
   }
 }

--- a/ui/src/app/components/toaster/toaster.component.ts
+++ b/ui/src/app/components/toaster/toaster.component.ts
@@ -25,6 +25,7 @@ export class ToasterComponent implements OnInit, OnDestroy {
     private cdr: ChangeDetectorRef,
   ) {}
 
+
   ngOnInit() {
     this.toastSubscription = this.toasterService.getToasts().subscribe((toast) => {
       this.addToast(toast);
@@ -32,6 +33,9 @@ export class ToasterComponent implements OnInit, OnDestroy {
   }
 
   addToast(toast: any) {
+    if (!toast.message || toast.message.trim() === '') {
+      return;
+    }
     const newToast = { ...toast, show: true };
     this.toasts = [newToast];
     this.cdr.detectChanges();

--- a/ui/src/app/constants/llm.models.constants.ts
+++ b/ui/src/app/constants/llm.models.constants.ts
@@ -5,12 +5,8 @@ export const AvailableProviders = [
   { displayName: 'AWS Bedrock', key: 'OPENAI_COMPATIBLE_CLAUDE' },
 ];
 
-export const DefaultProvider = AvailableProviders[0].key;
-
 export const providerModelMap: { [key: string]: string[] } = {
     OPENAI_NATIVE: ['gpt-4o', 'gpt-4o-mini'],
     OPENAI_COMPATIBLE_AZURE: ['gpt-4o', 'gpt-4o-mini'],
     OPENAI_COMPATIBLE_CLAUDE: ['anthropic.claude-3-5-sonnet-20240620-v1:0']
 };
-
-  export const DefaultLLMModel = providerModelMap[DefaultProvider][0]

--- a/ui/src/app/constants/toast.constant.ts
+++ b/ui/src/app/constants/toast.constant.ts
@@ -17,3 +17,5 @@ export const APP_INTEGRATIONS = {
     ERROR: 'Failed to Update AWS Bedrock Knowledge Base Config',
   },
 };
+
+export const DEFAULT_TOAST_DURATION = 5000;

--- a/ui/src/app/interceptor/http.interceptor.ts
+++ b/ui/src/app/interceptor/http.interceptor.ts
@@ -12,7 +12,6 @@ import { Store } from '@ngxs/store';
 import { LoadingService } from '../services/loading.service';
 import { LLMConfigState } from '../store/llm-config/llm-config.state';
 import { ToasterService } from '../services/toaster/toaster.service';
-import { DefaultLLMModel, DefaultProvider } from '../constants/llm.models.constants';
 
 @Injectable()
 export class LoadingInterceptor implements HttpInterceptor {
@@ -33,8 +32,8 @@ export class LoadingInterceptor implements HttpInterceptor {
 
     const modifiedRequest = request.clone({
       setHeaders: {
-        'X-Provider': provider || DefaultProvider,
-        'X-Model': model || DefaultLLMModel,
+        'X-Provider': provider,
+        'X-Model': model,
       },
     });
 

--- a/ui/src/app/pages/login/login.component.ts
+++ b/ui/src/app/pages/login/login.component.ts
@@ -91,9 +91,8 @@ export class LoginComponent implements OnInit {
       this.electronService.setStoreValue("APP_CONFIG", newConfig);
       localStorage.setItem(APP_CONSTANTS.APP_URL, updatedAppUrl as string);
       localStorage.setItem(APP_CONSTANTS.WORKING_DIR, newConfig.directoryPath as string);
-      this.logger.debug(updatedAppUrl, passcode);
+      this.logger.debug('Login attempt', updatedAppUrl);
 
-      this.logger.debug(updatedAppUrl);
       this.authService
         .login({
           appUrl: `${updatedAppUrl}/`,
@@ -101,23 +100,19 @@ export class LoginComponent implements OnInit {
         })
         .subscribe({
           next: (res: any) => {
-            this.logger.debug('logging successful', res);
+            this.logger.debug('Login successful', res);
             localStorage.setItem(
               APP_CONSTANTS.APP_PASSCODE_KEY,
               btoa(passcode) as string,
             );
 
             this.authService.setIsLoggedIn(true);
-
-            this.routerService
-              .navigate(['/apps'])
-              .then()
-              .catch((err) => this.logger.error(err));
+            this.routerService.navigate(['/apps']).catch((err) => this.logger.error(err));
           },
           error: (_) => {
             this.authService.setIsLoggedIn(false);
             localStorage.removeItem(APP_CONSTANTS.APP_URL);
-            localStorage.removeItem(APP_CONSTANTS.APP_PASSCODE_KEY)
+            localStorage.removeItem(APP_CONSTANTS.APP_PASSCODE_KEY);
             this.toastService.showError(
               'Your Server URL or passcode is incorrect. Please try again',
             );

--- a/ui/src/app/services/auth/auth.service.ts
+++ b/ui/src/app/services/auth/auth.service.ts
@@ -59,15 +59,8 @@ export class AuthService {
         } else {
           return this.store.dispatch(new FetchDefaultLLMConfig());
         }
-      }),
-      tap(() => this.syncConfigWithLocalStorage())
+      })
     );
-  }
-
-  private syncConfigWithLocalStorage(): void {
-    this.store.selectOnce(LLMConfigState.getConfig).subscribe(config => {
-      localStorage.setItem('llmConfig', JSON.stringify(config));
-    });
   }
 
   public encodeAccessCode(accessCode: string): string {

--- a/ui/src/app/services/auth/auth.service.ts
+++ b/ui/src/app/services/auth/auth.service.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { tap, switchMap, catchError } from 'rxjs/operators';
 import { AuthStateService } from './auth-state.service';
 import { APP_CONSTANTS } from '../../constants/app.constants';
+import { Store } from '@ngxs/store';
+import { SetLLMConfig, FetchDefaultLLMConfig, VerifyLLMConfig } from '../../store/llm-config/llm-config.actions';
+import { ToasterService } from '../toaster/toaster.service';
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +17,9 @@ export class AuthService {
     private router: Router,
     private route: ActivatedRoute,
     private http: HttpClient,
-    private authState: AuthStateService
+    private authState: AuthStateService,
+    private store: Store,
+    private toasterService: ToasterService
   ) {
     this.verifyTokenOnInit();
   }
@@ -24,20 +29,35 @@ export class AuthService {
       const encodedPasscode = localStorage.getItem(APP_CONSTANTS.APP_PASSCODE_KEY)!;
       const appUrl = localStorage.getItem(APP_CONSTANTS.APP_URL)!;
       
-      this.verifyAccessToken(encodedPasscode, appUrl).subscribe({
-        next: (response) => {
+      this.verifyAccessToken(encodedPasscode, appUrl).pipe(
+        switchMap((response) => {
           if (response.valid) {
-            // Get return URL from query params or default to '/apps'
-            const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/apps';
-            this.router.navigateByUrl(returnUrl);
+            return this.initializeLLMConfig();
           } else {
             this.authState.logout('Invalid token. Please log in again.');
+            return of(null);
           }
+        })
+      ).subscribe({
+        next: () => {
+          const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/apps';
+          this.router.navigateByUrl(returnUrl);
         },
         error: () => {
-          this.authState.logout('Error verifying token. Please log in again.');
+          this.authState.logout('Error verifying token or initializing LLM config. Please log in again.');
         },
       });
+    }
+  }
+
+  public initializeLLMConfig(): Observable<any> {
+    const savedConfig = localStorage.getItem('llmConfig');
+    if (savedConfig) {
+      const config = JSON.parse(savedConfig);
+      this.store.dispatch(new SetLLMConfig(config));
+      return this.store.dispatch(new VerifyLLMConfig());
+    } else {
+      return this.store.dispatch(new FetchDefaultLLMConfig());
     }
   }
 
@@ -67,13 +87,12 @@ export class AuthService {
       accessToken: encodedPasscode,
       appUrl: data.appUrl,
     }).pipe(
-      tap(response => {
+      switchMap(response => {
         if (response.valid) {
           this.authState.setIsLoggedIn(true);
-          // Get return URL from query params or default to '/apps'
-          const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/apps';
-          this.router.navigateByUrl(returnUrl);
+          return of(response);
         }
+        return of(response);
       })
     );
   }

--- a/ui/src/app/services/auth/auth.service.ts
+++ b/ui/src/app/services/auth/auth.service.ts
@@ -96,12 +96,11 @@ export class AuthService {
       accessToken: encodedPasscode,
       appUrl: data.appUrl,
     }).pipe(
-      switchMap(response => {
+      tap(response => {
         if (response.valid) {
           this.authState.setIsLoggedIn(true);
-          return of(response);
+          this.initializeLLMConfig().subscribe();
         }
-        return of(response);
       })
     );
   }

--- a/ui/src/app/services/toaster/toaster.service.ts
+++ b/ui/src/app/services/toaster/toaster.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Subject, Observable, timer } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { Subject, Observable } from 'rxjs';
+import { DEFAULT_TOAST_DURATION } from 'src/app/constants/toast.constant';
 
 @Injectable({
   providedIn: 'root',
@@ -15,40 +15,25 @@ export class ToasterService {
     return this.toastSubject.asObservable();
   }
 
-  showToast(type: string, message: string, duration: number = 5000) {
+  showToast(type: string, message: string, duration: number = DEFAULT_TOAST_DURATION) {
     this.id++;  // Increment the ID to ensure it's unique for every toast
     const toastId = this.id;
-    this.toastSubject.next({ id: toastId, type, message });
-
-    // Auto-dismiss the toast after the specified duration
-    timer(duration).pipe(
-      takeUntil(this.toastSubject.pipe(
-        // Stop the timer if a new toast with the same ID is shown
-        // (which shouldn't happen, but just in case)
-        filter(toast => toast.id === toastId)
-      ))
-    ).subscribe(() => {
-      this.dismissToast(toastId);
-    });
+    this.toastSubject.next({ id: toastId, type, message, duration });
   }
 
-  showSuccess(message: string, duration: number = 5000) {
+  showSuccess(message: string, duration: number = DEFAULT_TOAST_DURATION) {
     this.showToast('success', message, duration);
   }
 
-  showError(message: string, duration: number = 5000) {
+  showError(message: string, duration: number = DEFAULT_TOAST_DURATION) {
     this.showToast('error', message, duration);
   }
 
-  showInfo(message: string, duration: number = 5000) {
+  showInfo(message: string, duration: number = DEFAULT_TOAST_DURATION) {
     this.showToast('info', message, duration);
   }
   
-  showWarning(message: string, duration: number = 5000) {
+  showWarning(message: string, duration: number = DEFAULT_TOAST_DURATION) {
     this.showToast('warning', message, duration);
-  }
-
-  private dismissToast(id: number) {
-    this.toastSubject.next({ id, type: 'dismiss' });
   }
 }

--- a/ui/src/app/services/toaster/toaster.service.ts
+++ b/ui/src/app/services/toaster/toaster.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, timer } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -14,24 +15,40 @@ export class ToasterService {
     return this.toastSubject.asObservable();
   }
 
-  showToast(type: string, message: string) {
+  showToast(type: string, message: string, duration: number = 5000) {
     this.id++;  // Increment the ID to ensure it's unique for every toast
-    this.toastSubject.next({ id: this.id, type, message });
+    const toastId = this.id;
+    this.toastSubject.next({ id: toastId, type, message });
+
+    // Auto-dismiss the toast after the specified duration
+    timer(duration).pipe(
+      takeUntil(this.toastSubject.pipe(
+        // Stop the timer if a new toast with the same ID is shown
+        // (which shouldn't happen, but just in case)
+        filter(toast => toast.id === toastId)
+      ))
+    ).subscribe(() => {
+      this.dismissToast(toastId);
+    });
   }
 
-  showSuccess(message: string) {
-    this.showToast('success', message);
+  showSuccess(message: string, duration: number = 5000) {
+    this.showToast('success', message, duration);
   }
 
-  showError(message: string) {
-    this.showToast('error', message);
+  showError(message: string, duration: number = 5000) {
+    this.showToast('error', message, duration);
   }
 
-  showInfo(message: string) {
-    this.showToast('info', message);
+  showInfo(message: string, duration: number = 5000) {
+    this.showToast('info', message, duration);
   }
   
-  showWarning(message: string) {
-    this.showToast('warning', message);
+  showWarning(message: string, duration: number = 5000) {
+    this.showToast('warning', message, duration);
+  }
+
+  private dismissToast(id: number) {
+    this.toastSubject.next({ id, type: 'dismiss' });
   }
 }

--- a/ui/src/app/store/llm-config/llm-config.actions.ts
+++ b/ui/src/app/store/llm-config/llm-config.actions.ts
@@ -12,3 +12,7 @@ export class FetchDefaultLLMConfig {
 export class VerifyLLMConfig {
     static readonly type = '[LLMConfig] Verify';
 }
+
+export class SyncLLMConfig {
+    static readonly type = '[LLMConfig] Sync';
+}

--- a/ui/src/app/store/llm-config/llm-config.actions.ts
+++ b/ui/src/app/store/llm-config/llm-config.actions.ts
@@ -1,6 +1,14 @@
-import { LLMConfigModel } from "../..//model/interfaces/ILLMConfig";
+import { LLMConfigModel } from "../../model/interfaces/ILLMConfig";
 
 export class SetLLMConfig {
     static readonly type = '[LLMConfig] Set';
     constructor(public payload: LLMConfigModel) { }
+}
+
+export class FetchDefaultLLMConfig {
+    static readonly type = '[LLMConfig] Fetch Default';
+}
+
+export class VerifyLLMConfig {
+    static readonly type = '[LLMConfig] Verify';
 }

--- a/ui/src/app/store/llm-config/llm-config.state.ts
+++ b/ui/src/app/store/llm-config/llm-config.state.ts
@@ -9,6 +9,7 @@ import { LoadingService } from '../../services/loading.service';
 import { ToasterService } from '../../services/toaster/toaster.service';
 import { AvailableProviders } from '../../constants/llm.models.constants';
 import { ElectronService } from '../../services/electron/electron.service';
+import { DEFAULT_TOAST_DURATION } from 'src/app/constants/toast.constant';
 
 export interface LLMConfigStateModel extends LLMConfigModel {
   isDefault: boolean;
@@ -94,7 +95,7 @@ export class LLMConfigState {
           this.http.get<LLMConfigModel>('llm-config/defaults').pipe(
             tap((defaultConfig) => {
               const defaultProviderDisplayName = AvailableProviders.find(p => p.key === defaultConfig.provider)?.displayName || defaultConfig.provider;
-              this.toasterService.showInfo(`LLM configuration error. Reset to default LLM configuration - ${defaultProviderDisplayName} : ${defaultConfig.model}`, 5000);
+              this.toasterService.showInfo(`LLM configuration error. Resetting to default LLM configuration - ${defaultProviderDisplayName} : ${defaultConfig.model}`, DEFAULT_TOAST_DURATION);
               dispatch(new FetchDefaultLLMConfig());
             }),
             catchError((error) => {
@@ -103,10 +104,9 @@ export class LLMConfigState {
               return of(null);
             })
           ).subscribe();
-        } else {
-          this.toasterService.showSuccess(`${providerDisplayName} : ${state.model} is configured successfully.`, 5000);
-          dispatch(new SyncLLMConfig());
         }
+        // Always sync the config after verification, regardless of success or failure
+        dispatch(new SyncLLMConfig());
       }),
       catchError((error) => {
         console.error('Error verifying LLM config:', error);

--- a/ui/src/app/store/llm-config/llm-config.state.ts
+++ b/ui/src/app/store/llm-config/llm-config.state.ts
@@ -1,26 +1,88 @@
 import { State, Action, StateContext, Selector } from '@ngxs/store';
+import { Injectable } from '@angular/core';
 import { LLMConfigModel } from "../../model/interfaces/ILLMConfig";
-import { SetLLMConfig } from './llm-config.actions';
-import { DefaultLLMModel, DefaultProvider } from '../../constants/llm.models.constants';
+import { SetLLMConfig, FetchDefaultLLMConfig, VerifyLLMConfig } from './llm-config.actions';
+import { tap, catchError, finalize } from 'rxjs/operators';
+import { HttpClient } from '@angular/common/http';
+import { of } from 'rxjs';
+import { LoadingService } from '../../services/loading.service';
+import { ToasterService } from '../../services/toaster/toaster.service';
 
-@State<LLMConfigModel>({
+export interface LLMConfigStateModel extends LLMConfigModel {
+  isDefault: boolean;
+}
+
+@State<LLMConfigStateModel>({
   name: 'LLMConfig',
   defaults: {
     apiKey: '',
-    model: DefaultLLMModel,
-    provider: DefaultProvider,
-    apiUrl: ''
+    model: '',
+    provider: '',
+    apiUrl: '',
+    isDefault: true
   }
 })
+@Injectable()
 export class LLMConfigState {
+  constructor(
+    private http: HttpClient,
+    private loadingService: LoadingService,
+    private toastService: ToasterService
+  ) {}
 
   @Selector()
-  static getConfig(state: LLMConfigModel) {
+  static getConfig(state: LLMConfigStateModel) {
     return state;
   }
 
   @Action(SetLLMConfig)
-  setLLMConfig({ setState }: StateContext<LLMConfigModel>, { payload }: SetLLMConfig) {
-    setState({ ...payload });
+  setLLMConfig({ setState }: StateContext<LLMConfigStateModel>, { payload }: SetLLMConfig) {
+    setState({ ...payload, isDefault: false });
+  }
+
+  @Action(FetchDefaultLLMConfig)
+  fetchDefaultLLMConfig({ setState }: StateContext<LLMConfigStateModel>) {
+    this.loadingService.setLoading(true);
+    return this.http.get<LLMConfigModel>('llm-config/defaults').pipe(
+      tap((defaultConfig) => {
+        setState({ ...defaultConfig, isDefault: true });
+      }),
+      catchError((error) => {
+        console.error('Error fetching default LLM config:', error);
+        this.toastService.showError('Failed to fetch default LLM configuration.');
+        return of({ provider: '', model: '' });
+      }),
+      finalize(() => {
+        this.loadingService.setLoading(false);
+      })
+    );
+  }
+
+  @Action(VerifyLLMConfig)
+  verifyLLMConfig({ getState, dispatch }: StateContext<LLMConfigStateModel>) {
+    const state = getState();
+    this.loadingService.setLoading(true);
+    return this.http.post('model/config-verification', {
+      provider: state.provider,
+      model: state.model
+    }).pipe(
+      tap((response: any) => {
+        if (response.status === 'failed') {
+          this.toastService.showError('Current provider configuration verification failed. Setting to default provider configuration');
+          dispatch(new FetchDefaultLLMConfig());
+        } else {
+          this.toastService.showSuccess('Provider configuration verified and saved successfully');
+        }
+      }),
+      catchError((error) => {
+        console.error('Error verifying LLM config:', error);
+        this.toastService.showError('Failed to verify provider and model configuration');
+        dispatch(new FetchDefaultLLMConfig());
+        return of(null);
+      }),
+      finalize(() => {
+        this.loadingService.setLoading(false);
+      })
+    );
   }
 }

--- a/ui/src/app/store/llm-config/llm-config.state.ts
+++ b/ui/src/app/store/llm-config/llm-config.state.ts
@@ -84,7 +84,7 @@ export class LLMConfigState {
           this.http.get<LLMConfigModel>('llm-config/defaults').pipe(
             tap((defaultConfig) => {
               const defaultProviderDisplayName = AvailableProviders.find(p => p.key === defaultConfig.provider)?.displayName || defaultConfig.provider;
-              this.toasterService.showError(`Current provider configuration verification failed. Setting to default provider configuration - ${defaultProviderDisplayName} : ${defaultConfig.model}`, 5000);
+              this.toasterService.showError(`Something went wrong. Reset to default LLM configuration - ${defaultProviderDisplayName} : ${defaultConfig.model}`, 5000);
               dispatch(new FetchDefaultLLMConfig());
             }),
             catchError((error) => {
@@ -94,7 +94,7 @@ export class LLMConfigState {
             })
           ).subscribe();
         } else {
-          this.toasterService.showSuccess(`${providerDisplayName} : ${state.model} is now configured successfully.`, 5000);
+          this.toasterService.showSuccess(`${providerDisplayName} : ${state.model} is configured successfully.`, 5000);
           dispatch(new SyncLLMConfig());
         }
       }),


### PR DESCRIPTION
- Added a new endpoint `/api/llm-config/defaults` in the backend to fetch the default `model` and `provider`
- On the application frontend, 
        - Remove the default options selected for LLM Provider and Model
        - When logged in or re-fresh, Check with existing LLM configuration settings,
        - If configuration is valid, use same settings
        - If configuration is invalid, set with default configuration settings
- Modified toast message to disappear automatically after 5 seconds
