### PR TITLE
feat(ci): Update GitHub Actions to sync with GitLab release/QA branch

### DIFF
--- a/.github/workflows/sync-github-to-gitlab.yml
+++ b/.github/workflows/sync-github-to-gitlab.yml
@@ -29,7 +29,7 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H gitlab.presidio.com >> ~/.ssh/known_hosts
 
-      # Step 4: Add GitLab remote
+      # Step 4: Add GitLab remote 
       - name: Add GitLab remote
         run: git remote add gitlab git@gitlab.presidio.com:hai-build/specif-ai-github.git
 

--- a/.github/workflows/sync-github-to-gitlab.yml
+++ b/.github/workflows/sync-github-to-gitlab.yml
@@ -33,19 +33,19 @@ jobs:
       - name: Add GitLab remote
         run: git remote add gitlab git@gitlab.presidio.com:hai-build/specif-ai-github.git
 
-      # Step 5: Fetch GitLab qa branch
-      - name: Fetch GitLab qa branch
-        run: git fetch gitlab qa || true  # Ensure GitLab qa branch is fetched
+      # Step 5: Fetch GitLab release/QA branch
+      - name: Fetch GitLab release/QA branch
+        run: git fetch gitlab release/QA || true  # Ensure GitLab release/QA branch is fetched
 
-      # Step 6: Checkout GitLab qa branch
-      - name: Checkout GitLab qa branch
+      # Step 6: Checkout GitLab release/QA branch
+      - name: Checkout GitLab release/QA branch
         run: |
-          git checkout qa || git checkout -b qa gitlab/qa
+          git checkout release/QA || git checkout -b release/QA gitlab/release/QA
 
-      # Step 7: Merge GitHub main into GitLab qa
-      - name: Merge GitHub main into GitLab qa
+      # Step 7: Merge GitHub main into GitLab release/QA
+      - name: Merge GitHub main into GitLab release/QA
         run: git merge origin/main --allow-unrelated-histories --strategy-option=theirs || true
 
-      # Step 8: Push only to GitLab qa
-      - name: Push Final Changes to GitLab qa branch
-        run: git push gitlab qa
+      # Step 8: Push only to GitLab release/QA
+      - name: Push Final Changes to GitLab release/QA branch
+        run: git push gitlab release/QA


### PR DESCRIPTION
Updated .github/workflows/sync-github-to-gitlab.yml to replace references to qa with release/QA.
Modified steps to:
- Fetch release/QA instead of qa.
- Checkout and merge into release/QA branch instead of qa.
- Push final changes to release/QA branch on GitLab.
- Ensured compatibility with GitLab repository structure.
