### PR TITLE
fix: set default LLM provider to OPENAI_NATIVE and model to gpt-4o when configuration is missing

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specif_ai",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specif_ai",
-      "version": "1.9.5",
+      "version": "1.9.6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/ui/src/app/components/llm-settings/llm-settings.component.ts
+++ b/ui/src/app/components/llm-settings/llm-settings.component.ts
@@ -3,7 +3,7 @@ import { LLMConfigState } from 'src/app/store/llm-config/llm-config.state';
 import { distinctUntilChanged, Observable, Subscription } from 'rxjs';
 import { LLMConfigModel } from '../../model/interfaces/ILLMConfig';
 import { Store } from '@ngxs/store';
-import { AvailableProviders, providerModelMap } from '../../constants/llm.models.constants';
+import { AvailableProviders, ProviderModelMap } from '../../constants/llm.models.constants';
 import { SetLLMConfig, SyncLLMConfig } from '../../store/llm-config/llm-config.actions';
 import { MatDialogRef } from '@angular/material/dialog';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
@@ -80,7 +80,7 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
         .pipe(distinctUntilChanged())
         .subscribe((res) => {
           this.updateFilteredModels(res);
-          this.selectedModel.setValue(providerModelMap[res][0]);
+          this.selectedModel.setValue(ProviderModelMap[res][0]);
           this.errorMessage = '';
           this.hasChanges = 
             this.selectedModel.value !== this.initialModel || 
@@ -91,7 +91,7 @@ export class LlmSettingsComponent implements OnInit, OnDestroy {
   }
 
   updateFilteredModels(provider: string) {
-    this.filteredModels = providerModelMap[provider] || [];
+    this.filteredModels = ProviderModelMap[provider] || [];
   }
 
   closeModal() {

--- a/ui/src/app/constants/llm.models.constants.ts
+++ b/ui/src/app/constants/llm.models.constants.ts
@@ -5,7 +5,7 @@ export const AvailableProviders = [
   { displayName: 'AWS Bedrock', key: 'OPENAI_COMPATIBLE_CLAUDE' },
 ];
 
-export const providerModelMap: { [key: string]: string[] } = {
+export const ProviderModelMap: { [key: string]: string[] } = {
     OPENAI_NATIVE: ['gpt-4o', 'gpt-4o-mini'],
     OPENAI_COMPATIBLE_AZURE: ['gpt-4o', 'gpt-4o-mini'],
     OPENAI_COMPATIBLE_CLAUDE: ['anthropic.claude-3-5-sonnet-20240620-v1:0']


### PR DESCRIPTION
fix: set default LLM provider to OPENAI_NATIVE and model to gpt-4o when configuration is missing

Closes #20 