### PR TITLE
fix: remove 401 error toast during invalid login credentials

### DIFF
--- a/ui/src/app/interceptor/http.interceptor.ts
+++ b/ui/src/app/interceptor/http.interceptor.ts
@@ -48,7 +48,9 @@ export class LoadingInterceptor implements HttpInterceptor {
           if (error.status >= 500) {
             return timer(1);
           }
-          this.toasterService.showError(error?.message);
+          if (!(request.url.includes('auth/verify_access_token') && (error.status === 401 || error.status === 403))) {
+            this.toasterService.showError(error?.message);
+          }
           throw error;
         },
       }),


### PR DESCRIPTION
fix: remove 401 error toast during invalid login credentials.

Screenshot after fixing the issue. Only one toaster will be displayed while invalid login credentials.

![image](https://github.com/user-attachments/assets/1daa9637-ed40-41ac-b73f-8a711693a4a1)
