### PR TITLE
Fix: Disable Send Button for Empty Messages in Chat

### DIFF
--- a/ui/src/app/components/ai-chat/ai-chat.component.ts
+++ b/ui/src/app/components/ai-chat/ai-chat.component.ts
@@ -345,7 +345,7 @@ export class AiChatComponent implements OnInit {
   }
 
   get isSendDisabled(): boolean {
-    return this.generateLoader || (!this.message && this.selectedFiles.length === 0);
+    return this.generateLoader || (!this.message?.trim() && this.selectedFiles.length === 0);
   }
 
   onKbToggle(isActive: boolean) {


### PR DESCRIPTION
## Description  
This PR fixes a bug where users could send empty messages by pressing the Enter key in the chat text area. Now, the send button is disabled if the trimmed message is empty, preventing unintended blank messages.

## Fix Implemented  
- Trimmed the input before enabling the send button.  
- Disabled the send button when the input is empty or only contains spaces.  
