### PR TITLE
fix: Trim App URL Before Verification to Prevent Login Failures

### DIFF
--- a/ui/src/app/pages/login/login.component.ts
+++ b/ui/src/app/pages/login/login.component.ts
@@ -77,10 +77,7 @@ export class LoginComponent implements OnInit {
         appUrl: string;
         passcode: string;
       };
-      const updatedAppUrl =
-        appUrl[appUrl.length - 1] === '/'
-          ? appUrl.slice(0, appUrl.length - 1)
-          : `${appUrl}`;
+      const updatedAppUrl = appUrl.trim().replace(/\/+$/, '');
 
       const newConfig = {
         appUrl: updatedAppUrl,


### PR DESCRIPTION
This update ensures that any unnecessary white spaces in the App URL entered by the user are trimmed before sending it for verification. Previously, extra spaces caused authentication failures. With this fix, the app will now automatically sanitize the input.