### PR TITLE
fix: removing file read operations to avoid state change

### DIFF
--- a/.changeset/eleven-dragons-sink.md
+++ b/.changeset/eleven-dragons-sink.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix for task chat to stay in same page

--- a/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
+++ b/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
@@ -195,14 +195,12 @@ export class EditUserStoriesComponent implements OnDestroy {
               }),
             );
             this.allowFreeRedirection = true;
-            this.store.dispatch(new ReadFile(`${this.folderName}/${this.fileName}`));
-            this.selectedFileContent$.subscribe((res: any) => {
-              let updatedDescription = findUserStory(res, this.data.id).description
-              this.userStoryForm.patchValue({
-                description: updatedDescription
-              });
-              this.description = updatedDescription;
+            this.userStoryForm.patchValue({
+              name: featureName,
+              description: featureDescription
             });
+            this.name = featureName!;
+            this.description = featureDescription;
             this.toasterService.showSuccess(
               TOASTER_MESSAGES.ENTITY.UPDATE.SUCCESS(
                 this.entityType,
@@ -233,14 +231,6 @@ export class EditUserStoriesComponent implements OnDestroy {
         }),
       );
       this.allowFreeRedirection = true;
-      this.store.dispatch(new ReadFile(`${this.folderName}/${this.fileName}`));
-      this.selectedFileContent$.subscribe((res: any) => {
-        let updatedDescription = findUserStory(res, this.data.id).description
-        this.userStoryForm.patchValue({
-          description: updatedDescription
-        });
-        this.description = updatedDescription;
-      });
       this.toasterService.showSuccess(
         TOASTER_MESSAGES.ENTITY.UPDATE.SUCCESS(
           this.entityType,


### PR DESCRIPTION
### Description

The chat breaks after editing a user story because a `ReadFile` is performed, which updates the `selectedFileContent` in the global state. This was added to read the updated content and update the user story component accordingly. However, this action overwrites the `selectedFileContent`, which is supposed to hold the PRDxx-base.json content, with the PRDxx-feature.json content. When navigating to the Task page, it tries to access the `requirement` attribute from the PRDxx-base.json content in the `selectedFileContent`. Due to the overwrite, the requirement attribute becomes undefined, causing the chat to break as the payload's attribute is undefined. This PR fixes this issue.
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [ ] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [ ] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
