### PR TITLE
fix: Prevent solution creation with spaces-only input

### DIFF
--- a/.changeset/warm-ravens-wish.md
+++ b/.changeset/warm-ravens-wish.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix: Prevent solution creation with spaces-only input in required fields by trimming values before form submission

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -4,9 +4,6 @@ import {
   FormGroup,
   ReactiveFormsModule,
   Validators,
-  AbstractControl,
-  ValidationErrors,
-  ValidatorFn,
 } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@ngxs/store';
@@ -72,26 +69,19 @@ export class CreateSolutionComponent implements OnInit {
     );
   }
 
-  noWhitespaceValidator(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const isWhitespace = (control.value || '').trim().length === 0;
-      return isWhitespace ? { whitespace: true } : null;
-    };
-  }
-
   createSolutionForm() {
     return new FormGroup({
       name: new FormControl('', [
         Validators.required,
-        this.noWhitespaceValidator(),
+        Validators.pattern(/\S/),
       ]),
       description: new FormControl('', [
         Validators.required,
-        this.noWhitespaceValidator(),
+        Validators.pattern(/\S/),
       ]),
       technicalDetails: new FormControl('', [
         Validators.required,
-        this.noWhitespaceValidator(),
+        Validators.pattern(/\S/),
       ]),
       createReqt: new FormControl(true),
       id: new FormControl(uuid()),

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -4,6 +4,9 @@ import {
   FormGroup,
   ReactiveFormsModule,
   Validators,
+  AbstractControl,
+  ValidationErrors,
+  ValidatorFn,
 } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Store } from '@ngxs/store';
@@ -69,11 +72,27 @@ export class CreateSolutionComponent implements OnInit {
     );
   }
 
+  noWhitespaceValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const isWhitespace = (control.value || '').trim().length === 0;
+      return isWhitespace ? { whitespace: true } : null;
+    };
+  }
+
   createSolutionForm() {
     return new FormGroup({
-      name: new FormControl('', Validators.required),
-      description: new FormControl('', Validators.required),
-      technicalDetails: new FormControl('', Validators.required),
+      name: new FormControl('', [
+        Validators.required,
+        this.noWhitespaceValidator(),
+      ]),
+      description: new FormControl('', [
+        Validators.required,
+        this.noWhitespaceValidator(),
+      ]),
+      technicalDetails: new FormControl('', [
+        Validators.required,
+        this.noWhitespaceValidator(),
+      ]),
       createReqt: new FormControl(true),
       id: new FormControl(uuid()),
       createdAt: new FormControl(new Date().toISOString()),


### PR DESCRIPTION
### Description

This PR addresses an issue where users could create solutions by entering only spaces in required fields (name, description, and technical details). The fix ensures that input validation properly handles whitespace-only entries.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

