### PR TITLE
refactor: Implement type-wise requirement ID counters in metadata

### DIFF
--- a/.changeset/huge-otters-sneeze.md
+++ b/.changeset/huge-otters-sneeze.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+Refactored ID generation logic by introducing type-wise counters for requirements.

--- a/electron/file-system.utility.js
+++ b/electron/file-system.utility.js
@@ -16,6 +16,7 @@ const utilityFunctionMap = {
   readMetadataFile: readMetadataFile,
   createRequestedDirectory: createRequestedDirectory,
   archiveFile: archiveFile,
+  getBaseFileCount: getBaseFileCount,
 };
 
 function createDirectoryWithMetadata(param) {
@@ -124,6 +125,18 @@ function getDirectoryList(param) {
   }
 }
 
+async function getBaseFileCount({ path }) {
+  const keyName = pathModule.basename(path);
+  try {
+    const files = await fsPromise.readdir(path);
+    return files.filter(
+      (file) => file.startsWith(keyName) && file.includes("-base")
+    ).length;
+  } catch (err) {
+    console.error("Error reading files in directory:", err);
+  }
+}
+
 async function appendFile({ path, content, featureFile, baseFileCount }) {
   const keyName = pathModule.basename(path);
 
@@ -142,10 +155,7 @@ async function appendFile({ path, content, featureFile, baseFileCount }) {
 
   try {
     if (baseFileCount === -1) {
-      const files = await fsPromise.readdir(path);
-      baseFileCount = files.filter(
-        (file) => file.startsWith(keyName) && file.includes("-base")
-      ).length;
+      baseFileCount = await getBaseFileCount({ path });
     }
 
     const fileCount = baseFileCount;

--- a/electron/file-system.utility.js
+++ b/electron/file-system.utility.js
@@ -128,10 +128,13 @@ function getDirectoryList(param) {
 async function getBaseFileCount({ path }) {
   const keyName = pathModule.basename(path);
   try {
-    const files = await fsPromise.readdir(path);
-    return files.filter(
-      (file) => file.startsWith(keyName) && file.includes("-base")
-    ).length;
+    if (fs.existsSync(path)) {
+      const files = await fsPromise.readdir(path);
+      return files.filter(
+        (file) => file.startsWith(keyName) && file.includes("-base")
+      ).length;
+    }
+    return 0;
   } catch (err) {
     console.error("Error reading files in directory:", err);
   }

--- a/electron/file-system.utility.js
+++ b/electron/file-system.utility.js
@@ -141,13 +141,14 @@ async function appendFile({ path, content, featureFile }) {
   }
 
   try {
-    const files = await fsPromise.readdir(path);
-    let fileCount = 0;
-    files.forEach((file) => {
-      if (file.startsWith(keyName) && file.includes("-base")) {
-        fileCount++;
-      }
-    });
+    if (baseFileCount === -1) {
+      const files = await fsPromise.readdir(path);
+      baseFileCount = files.filter(
+        (file) => file.startsWith(keyName) && file.includes("-base")
+      ).length;
+    }
+
+    const fileCount = baseFileCount;
 
     let newFileName =
       featureFile === ""
@@ -157,7 +158,7 @@ async function appendFile({ path, content, featureFile }) {
 
     await fsPromise.writeFile(newFilePath, content, "utf-8");
 
-    if (directoryPath.includes("PRD") && featureFile === "") {
+    if (path.includes("PRD") && featureFile === "") {
       const prdFileName = `${keyName}${(fileCount + 1).toString().padStart(2, "0")}-feature.json`;
       const prdFilePath = pathModule.join(path, prdFileName);
       await fsPromise.writeFile(
@@ -166,6 +167,7 @@ async function appendFile({ path, content, featureFile }) {
         "utf-8",
       );
     }
+    return fileCount;
   } catch (err) {
     console.error("Error handling files:", err);
   }

--- a/electron/file-system.utility.js
+++ b/electron/file-system.utility.js
@@ -124,7 +124,7 @@ function getDirectoryList(param) {
   }
 }
 
-async function appendFile({ path, content, featureFile }) {
+async function appendFile({ path, content, featureFile, baseFileCount }) {
   const keyName = pathModule.basename(path);
 
   try {

--- a/ui/src/app/constants/app.constants.ts
+++ b/ui/src/app/constants/app.constants.ts
@@ -226,3 +226,10 @@ export const FOLDER_REQUIREMENT_TYPE_MAP = {
 
 export type RequirementType =
   (typeof REQUIREMENT_TYPE)[keyof typeof REQUIREMENT_TYPE];
+
+export type RootRequirementType = Exclude<
+  RequirementType,
+  | typeof REQUIREMENT_TYPE.BP
+  | typeof REQUIREMENT_TYPE.TASK
+  | typeof REQUIREMENT_TYPE.US
+>;

--- a/ui/src/app/model/interfaces/projects.interface.ts
+++ b/ui/src/app/model/interfaces/projects.interface.ts
@@ -13,7 +13,7 @@ export interface IGenerationRange {
 export interface IRequirementConfig {
   enabled?: boolean;
   maxCount?: number;
-  counter: number;
+  count: number;
 }
 
 export interface IProjectMetadata {

--- a/ui/src/app/model/interfaces/projects.interface.ts
+++ b/ui/src/app/model/interfaces/projects.interface.ts
@@ -11,15 +11,9 @@ export interface IGenerationRange {
 }
 
 export interface IRequirementConfig {
-  enabled: boolean;
-  maxCount: number;
-}
-
-export interface IRequirements {
-  BRD: IRequirementConfig;
-  PRD: IRequirementConfig;
-  UIR: IRequirementConfig;
-  NFR: IRequirementConfig;
+  enabled?: boolean;
+  maxCount?: number;
+  counter: number;
 }
 
 export interface IProjectMetadata {
@@ -32,8 +26,13 @@ export interface IProjectMetadata {
   createReqt?: boolean;
   id: string;
   createdAt: string;
-  requirementsPreferences?: IRequirements;
-  requirementsIdCounter: Record<RequirementType, number>;
+  BRD: IRequirementConfig;
+  PRD: IRequirementConfig;
+  UIR: IRequirementConfig;
+  NFR: IRequirementConfig;
+  BP: IRequirementConfig;
+  US: IRequirementConfig;
+  TASK: IRequirementConfig;
 }
 
 export interface ICreateSolutionRequest {

--- a/ui/src/app/model/interfaces/projects.interface.ts
+++ b/ui/src/app/model/interfaces/projects.interface.ts
@@ -32,8 +32,8 @@ export interface IProjectMetadata {
   createReqt?: boolean;
   id: string;
   createdAt: string;
-  requirementsPreferences: IRequirements;
-  requirementsIdCounter?: Record<RequirementType, number>;
+  requirementsPreferences?: IRequirements;
+  requirementsIdCounter: Record<RequirementType, number>;
 }
 
 export interface ICreateSolutionRequest {

--- a/ui/src/app/model/interfaces/projects.interface.ts
+++ b/ui/src/app/model/interfaces/projects.interface.ts
@@ -1,3 +1,5 @@
+import { RequirementType } from 'src/app/constants/app.constants';
+
 export interface IProject {
   project: string;
   metadata: IProjectMetadata;
@@ -6,6 +8,18 @@ export interface IProject {
 export interface IGenerationRange {
   max_count: number;
   isEnabled: boolean;
+}
+
+export interface IRequirementConfig {
+  enabled: boolean;
+  maxCount: number;
+}
+
+export interface IRequirements {
+  BRD: IRequirementConfig;
+  PRD: IRequirementConfig;
+  UIR: IRequirementConfig;
+  NFR: IRequirementConfig;
 }
 
 export interface IProjectMetadata {
@@ -18,6 +32,8 @@ export interface IProjectMetadata {
   createReqt?: boolean;
   id: string;
   createdAt: string;
+  requirementsPreferences: IRequirements;
+  requirementsIdCounter?: Record<RequirementType, number>;
 }
 
 export interface ICreateSolutionRequest {

--- a/ui/src/app/pages/business-process/business-process.component.ts
+++ b/ui/src/app/pages/business-process/business-process.component.ts
@@ -209,7 +209,7 @@ export class BusinessProcessComponent implements OnInit {
     selectedPRDs: any[];
   }) {
     this.store.dispatch(
-      new CreateFile(`${this.folderName}/`, {
+      new CreateFile(`${this.folderName}`, {
         requirement: fileData.requirement,
         title: fileData.title,
         selectedBRDs: fileData.selectedBRDs,

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -150,10 +150,13 @@
                   <div class="flex items-center">
                     <div class="mt-1.5">
                       <app-toggle
-                        [isActive]="solutionForm.get('enableBRD')?.value"
-                        (toggleChange)="
-                          solutionForm.get('enableBRD')?.setValue($event)
+                        [isActive]="
+                          solutionForm
+                            .get('requirementsPreferences')
+                            ?.get('BRD')
+                            ?.get('enabled')?.value
                         "
+                        (toggleChange)="onRequirementToggle('BRD', $event)"
                         isPlainToggle="true"
                       ></app-toggle>
                     </div>
@@ -163,10 +166,20 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="solutionForm.get('enableBRD')?.value"
+                    *ngIf="
+                      solutionForm
+                        .get('requirementsPreferences')
+                        ?.get('BRD')
+                        ?.get('enabled')?.value
+                    "
                   >
-                    <div class="border rounded-lg p-4">
-                      <app-slider formControlName="brd"></app-slider>
+                    <div
+                      class="border rounded-lg p-4"
+                      formGroupName="requirementsPreferences"
+                    >
+                      <div formGroupName="BRD">
+                        <app-slider formControlName="maxCount"></app-slider>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -189,10 +202,13 @@
                   <div class="flex items-center">
                     <div class="mt-1.5">
                       <app-toggle
-                        [isActive]="solutionForm.get('enablePRD')?.value"
-                        (toggleChange)="
-                          solutionForm.get('enablePRD')?.setValue($event)
+                        [isActive]="
+                          solutionForm
+                            .get('requirementsPreferences')
+                            ?.get('PRD')
+                            ?.get('enabled')?.value
                         "
+                        (toggleChange)="onRequirementToggle('PRD', $event)"
                         isPlainToggle="true"
                       ></app-toggle>
                     </div>
@@ -202,10 +218,20 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="solutionForm.get('enablePRD')?.value"
+                    *ngIf="
+                      solutionForm
+                        .get('requirementsPreferences')
+                        ?.get('PRD')
+                        ?.get('enabled')?.value
+                    "
                   >
-                    <div class="border rounded-lg p-4">
-                      <app-slider formControlName="prd"></app-slider>
+                    <div
+                      class="border rounded-lg p-4"
+                      formGroupName="requirementsPreferences"
+                    >
+                      <div formGroupName="PRD">
+                        <app-slider formControlName="maxCount"></app-slider>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -226,10 +252,13 @@
                   <div class="flex items-center">
                     <div class="mt-1.5">
                       <app-toggle
-                        [isActive]="solutionForm.get('enableUIR')?.value"
-                        (toggleChange)="
-                          solutionForm.get('enableUIR')?.setValue($event)
+                        [isActive]="
+                          solutionForm
+                            .get('requirementsPreferences')
+                            ?.get('UIR')
+                            ?.get('enabled')?.value
                         "
+                        (toggleChange)="onRequirementToggle('UIR', $event)"
                         isPlainToggle="true"
                       ></app-toggle>
                     </div>
@@ -239,10 +268,20 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="solutionForm.get('enableUIR')?.value"
+                    *ngIf="
+                      solutionForm
+                        .get('requirementsPreferences')
+                        ?.get('UIR')
+                        ?.get('enabled')?.value
+                    "
                   >
-                    <div class="border rounded-lg p-4">
-                      <app-slider formControlName="uir"></app-slider>
+                    <div
+                      class="border rounded-lg p-4"
+                      formGroupName="requirementsPreferences"
+                    >
+                      <div formGroupName="UIR">
+                        <app-slider formControlName="maxCount"></app-slider>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -265,10 +304,13 @@
                   <div class="flex items-center">
                     <div class="mt-1.5">
                       <app-toggle
-                        [isActive]="solutionForm.get('enableNFR')?.value"
-                        (toggleChange)="
-                          solutionForm.get('enableNFR')?.setValue($event)
+                        [isActive]="
+                          solutionForm
+                            .get('requirementsPreferences')
+                            ?.get('NFR')
+                            ?.get('enabled')?.value
                         "
+                        (toggleChange)="onRequirementToggle('NFR', $event)"
                         isPlainToggle="true"
                       ></app-toggle>
                     </div>
@@ -279,10 +321,20 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="solutionForm.get('enableNFR')?.value"
+                    *ngIf="
+                      solutionForm
+                        .get('requirementsPreferences')
+                        ?.get('NFR')
+                        ?.get('enabled')?.value
+                    "
                   >
-                    <div class="border rounded-lg p-4">
-                      <app-slider formControlName="nfr"></app-slider>
+                    <div
+                      class="border rounded-lg p-4"
+                      formGroupName="requirementsPreferences"
+                    >
+                      <div formGroupName="NFR">
+                        <app-slider formControlName="maxCount"></app-slider>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -151,10 +151,7 @@
                     <div class="mt-1.5">
                       <app-toggle
                         [isActive]="
-                          solutionForm
-                            .get('requirementsPreferences')
-                            ?.get('BRD')
-                            ?.get('enabled')?.value
+                          solutionForm.get('BRD')?.get('enabled')?.value
                         "
                         (toggleChange)="onRequirementToggle('BRD', $event)"
                         isPlainToggle="true"
@@ -166,20 +163,10 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="
-                      solutionForm
-                        .get('requirementsPreferences')
-                        ?.get('BRD')
-                        ?.get('enabled')?.value
-                    "
+                    *ngIf="solutionForm.get('BRD')?.get('enabled')?.value"
                   >
-                    <div
-                      class="border rounded-lg p-4"
-                      formGroupName="requirementsPreferences"
-                    >
-                      <div formGroupName="BRD">
-                        <app-slider formControlName="maxCount"></app-slider>
-                      </div>
+                    <div class="border rounded-lg p-4" formGroupName="BRD">
+                      <app-slider formControlName="maxCount"></app-slider>
                     </div>
                   </div>
                 </div>
@@ -203,10 +190,7 @@
                     <div class="mt-1.5">
                       <app-toggle
                         [isActive]="
-                          solutionForm
-                            .get('requirementsPreferences')
-                            ?.get('PRD')
-                            ?.get('enabled')?.value
+                          solutionForm.get('PRD')?.get('enabled')?.value
                         "
                         (toggleChange)="onRequirementToggle('PRD', $event)"
                         isPlainToggle="true"
@@ -218,20 +202,10 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="
-                      solutionForm
-                        .get('requirementsPreferences')
-                        ?.get('PRD')
-                        ?.get('enabled')?.value
-                    "
+                    *ngIf="solutionForm.get('PRD')?.get('enabled')?.value"
                   >
-                    <div
-                      class="border rounded-lg p-4"
-                      formGroupName="requirementsPreferences"
-                    >
-                      <div formGroupName="PRD">
-                        <app-slider formControlName="maxCount"></app-slider>
-                      </div>
+                    <div class="border rounded-lg p-4" formGroupName="PRD">
+                      <app-slider formControlName="maxCount"></app-slider>
                     </div>
                   </div>
                 </div>
@@ -253,10 +227,7 @@
                     <div class="mt-1.5">
                       <app-toggle
                         [isActive]="
-                          solutionForm
-                            .get('requirementsPreferences')
-                            ?.get('UIR')
-                            ?.get('enabled')?.value
+                          solutionForm.get('UIR')?.get('enabled')?.value
                         "
                         (toggleChange)="onRequirementToggle('UIR', $event)"
                         isPlainToggle="true"
@@ -268,20 +239,10 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="
-                      solutionForm
-                        .get('requirementsPreferences')
-                        ?.get('UIR')
-                        ?.get('enabled')?.value
-                    "
+                    *ngIf="solutionForm.get('UIR')?.get('enabled')?.value"
                   >
-                    <div
-                      class="border rounded-lg p-4"
-                      formGroupName="requirementsPreferences"
-                    >
-                      <div formGroupName="UIR">
-                        <app-slider formControlName="maxCount"></app-slider>
-                      </div>
+                    <div class="border rounded-lg p-4" formGroupName="UIR">
+                      <app-slider formControlName="maxCount"></app-slider>
                     </div>
                   </div>
                 </div>
@@ -305,10 +266,7 @@
                     <div class="mt-1.5">
                       <app-toggle
                         [isActive]="
-                          solutionForm
-                            .get('requirementsPreferences')
-                            ?.get('NFR')
-                            ?.get('enabled')?.value
+                          solutionForm.get('NFR')?.get('enabled')?.value
                         "
                         (toggleChange)="onRequirementToggle('NFR', $event)"
                         isPlainToggle="true"
@@ -321,20 +279,10 @@
                   </div>
                   <div
                     class="mt-4"
-                    *ngIf="
-                      solutionForm
-                        .get('requirementsPreferences')
-                        ?.get('NFR')
-                        ?.get('enabled')?.value
-                    "
+                    *ngIf="solutionForm.get('NFR')?.get('enabled')?.value"
                   >
-                    <div
-                      class="border rounded-lg p-4"
-                      formGroupName="requirementsPreferences"
-                    >
-                      <div formGroupName="NFR">
-                        <app-slider formControlName="maxCount"></app-slider>
-                      </div>
+                    <div class="border rounded-lg p-4" formGroupName="NFR">
+                      <app-slider formControlName="maxCount"></app-slider>
                     </div>
                   </div>
                 </div>

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -71,6 +71,17 @@ export class CreateSolutionComponent implements OnInit {
     );
   }
 
+  private initRequirementGroup(enabled: boolean = true, maxCount: number = 15) {
+    return new FormGroup({
+      enabled: new FormControl(enabled),
+      maxCount: new FormControl(maxCount, [
+        Validators.required,
+        Validators.min(0),
+        Validators.max(30),
+      ]),
+    });
+  }
+
   createSolutionForm() {
     return new FormGroup({
       name: new FormControl('', [
@@ -89,30 +100,24 @@ export class CreateSolutionComponent implements OnInit {
       id: new FormControl(uuid()),
       createdAt: new FormControl(new Date().toISOString()),
       cleanSolution: new FormControl(false),
-      enableBRD: new FormControl(true),
-      enablePRD: new FormControl(true),
-      enableUIR: new FormControl(true),
-      enableNFR: new FormControl(true),
-      brd: new FormControl(15, [
-        Validators.required,
-        Validators.min(1),
-        Validators.max(30),
-      ]),
-      prd: new FormControl(15, [
-        Validators.required,
-        Validators.min(1),
-        Validators.max(30),
-      ]),
-      uir: new FormControl(15, [
-        Validators.required,
-        Validators.min(1),
-        Validators.max(30),
-      ]),
-      nfr: new FormControl(15, [
-        Validators.required,
-        Validators.min(1),
-        Validators.max(30),
-      ]),
+      requirementsPreferences: new FormGroup({
+        BRD: this.initRequirementGroup(),
+        PRD: this.initRequirementGroup(),
+        UIR: this.initRequirementGroup(),
+        NFR: this.initRequirementGroup(),
+      }),
+    });
+  }
+
+  onRequirementToggle(type: 'BRD' | 'PRD' | 'UIR' | 'NFR', enabled: boolean) {
+    const requirementGroup = this.solutionForm
+      .get('requirementsPreferences')
+      ?.get(type);
+
+    if (!requirementGroup) return;
+    requirementGroup.patchValue({
+      enabled,
+      maxCount: enabled ? 15 : 0,
     });
   }
 

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -22,6 +22,7 @@ import { ButtonComponent } from '../../components/core/button/button.component';
 import { ErrorMessageComponent } from '../../components/core/error-message/error-message.component';
 import {
   APP_CONSTANTS,
+  RootRequirementType,
   SOLUTION_CREATION_TOGGLE_MESSAGES,
 } from '../../constants/app.constants';
 import { InputFieldComponent } from '../../components/core/input-field/input-field.component';
@@ -72,14 +73,14 @@ export class CreateSolutionComponent implements OnInit {
   }
 
   private initRequirementGroup(enabled: boolean = true, maxCount: number = 15) {
-    return new FormGroup({
+    return {
       enabled: new FormControl(enabled),
       maxCount: new FormControl(maxCount, [
         Validators.required,
         Validators.min(0),
         Validators.max(30),
       ]),
-    });
+    };
   }
 
   createSolutionForm() {
@@ -100,20 +101,15 @@ export class CreateSolutionComponent implements OnInit {
       id: new FormControl(uuid()),
       createdAt: new FormControl(new Date().toISOString()),
       cleanSolution: new FormControl(false),
-      requirementsPreferences: new FormGroup({
-        BRD: this.initRequirementGroup(),
-        PRD: this.initRequirementGroup(),
-        UIR: this.initRequirementGroup(),
-        NFR: this.initRequirementGroup(),
-      }),
+      BRD: new FormGroup(this.initRequirementGroup()),
+      PRD: new FormGroup(this.initRequirementGroup()),
+      UIR: new FormGroup(this.initRequirementGroup()),
+      NFR: new FormGroup(this.initRequirementGroup()),
     });
   }
 
-  onRequirementToggle(type: 'BRD' | 'PRD' | 'UIR' | 'NFR', enabled: boolean) {
-    const requirementGroup = this.solutionForm
-      .get('requirementsPreferences')
-      ?.get(type);
-
+  onRequirementToggle(type: RootRequirementType, enabled: boolean) {
+    const requirementGroup = this.solutionForm.get(type);
     if (!requirementGroup) return;
     requirementGroup.patchValue({
       enabled,

--- a/ui/src/app/pages/tasks/add-task/add-task.component.ts
+++ b/ui/src/app/pages/tasks/add-task/add-task.component.ts
@@ -37,6 +37,7 @@ import { ErrorMessageComponent } from '../../../components/core/error-message/er
 import { ArchiveTask } from '../../../store/user-stories/user-stories.actions';
 import {
   CONFIRMATION_DIALOG,
+  REQUIREMENT_TYPE,
   TOASTER_MESSAGES,
 } from 'src/app/constants/app.constants';
 import { ConfirmationDialogComponent } from 'src/app/components/confirmation-dialog/confirmation-dialog.component';
@@ -44,6 +45,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
 import { provideIcons } from '@ng-icons/core';
 import { heroSparklesSolid } from '@ng-icons/heroicons/solid';
+import { RequirementIdService } from 'src/app/services/requirement-id.service';
 
 @Component({
   selector: 'app-add-task',
@@ -97,7 +99,6 @@ export class AddTaskComponent implements OnDestroy {
   editLabel: string = '';
   userStory: any = {};
   entityType: string = 'TASK';
-  totalTaskCount: number = 0;
   absoluteFilePath: string = '';
 
   existingTask: {
@@ -115,6 +116,7 @@ export class AddTaskComponent implements OnDestroy {
   constructor(
     private dialog: MatDialog,
     private toastService: ToasterService,
+    private requirementIdService: RequirementIdService,
   ) {
     this.mode = this.activatedRoute.snapshot.paramMap.get('mode') as
       | 'edit'
@@ -134,13 +136,6 @@ export class AddTaskComponent implements OnDestroy {
       this.prd = res;
     });
 
-    this.store
-      .select(UserStoriesState.getSelectedUserStory)
-      .subscribe((res) => {
-        this.userStory = res;
-        this.totalTaskCount =
-          (res?.tasks?.length || 0) + (res?.archivedTasks?.length || 0);
-      });
 
     this.createTaskForm(taskId);
     this.editLabel = this.mode == 'edit' ? 'Edit' : 'Add';
@@ -192,7 +187,7 @@ export class AddTaskComponent implements OnDestroy {
         '',
         Validators.compose([Validators.required]),
       ),
-      id: new FormControl(`TASK${this.totalTaskCount + 1}`),
+      id: new FormControl(taskId),
       useGenAI: new FormControl(false),
       fileContent: new FormControl(''),
       subTaskTicketId: new FormControl(''),
@@ -211,6 +206,14 @@ export class AddTaskComponent implements OnDestroy {
           list: task?.list,
           subTaskTicketId: task?.subTaskTicketId,
         });
+      });
+    } else {
+      const nextTaskId = this.requirementIdService.getNextRequirementId(
+        REQUIREMENT_TYPE.TASK,
+        true,
+      );
+      this.taskForm.patchValue({
+        id: `TASK${nextTaskId}`,
       });
     }
   }

--- a/ui/src/app/pages/tasks/add-task/add-task.component.ts
+++ b/ui/src/app/pages/tasks/add-task/add-task.component.ts
@@ -210,8 +210,14 @@ export class AddTaskComponent implements OnDestroy {
     } else {
       const nextTaskId = this.requirementIdService.getNextRequirementId(
         REQUIREMENT_TYPE.TASK,
-        true,
       );
+
+      this.requirementIdService
+        .updateRequirementCounters({
+          [REQUIREMENT_TYPE.TASK]: nextTaskId,
+        })
+        .then();
+
       this.taskForm.patchValue({
         id: `TASK${nextTaskId}`,
       });

--- a/ui/src/app/pages/tasks/task-list/task-list.component.ts
+++ b/ui/src/app/pages/tasks/task-list/task-list.component.ts
@@ -27,11 +27,15 @@ import { NgIconComponent } from '@ng-icons/core';
 import { ListItemComponent } from '../../../components/core/list-item/list-item.component';
 import { BadgeComponent } from '../../../components/core/badge/badge.component';
 import { ClipboardService } from '../../../services/clipboard.service';
-import { TOASTER_MESSAGES } from 'src/app/constants/app.constants';
+import {
+  REQUIREMENT_TYPE,
+  TOASTER_MESSAGES,
+} from 'src/app/constants/app.constants';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
 import { SearchInputComponent } from '../../../components/core/search-input/search-input.component';
 import { SearchService } from '../../../services/search/search.service';
 import { BehaviorSubject } from 'rxjs';
+import { RequirementIdService } from 'src/app/services/requirement-id.service';
 
 @Component({
   selector: 'app-task-list',
@@ -94,6 +98,7 @@ export class TaskListComponent implements OnInit, OnDestroy {
     private featureService: FeatureService,
     private loadingService: LoadingService,
     private toastService: ToasterService,
+    private requirementIdService: RequirementIdService,
   ) {
     this.userStoryId = this.activatedRoute.snapshot.paramMap.get('userStoryId');
     this.logger.debug('userStoryId', this.userStoryId);
@@ -203,12 +208,29 @@ export class TaskListComponent implements OnInit, OnDestroy {
   }
 
   updateWithUserStories(userStories: IUserStory, regenerate: boolean = false) {
+    let nextTaskId = this.requirementIdService.getNextRequirementId(
+      REQUIREMENT_TYPE.TASK,
+    );
+
+    const processedUserStory = {
+      ...userStories,
+      tasks: userStories.tasks?.map((task) => ({
+        ...task,
+        id: `TASK${nextTaskId++}`,
+      })),
+    };
+
     this.store.dispatch(
       new EditUserStory(
         `${this.config.folderName}/${this.config.newFileName}`,
-        userStories,
+        processedUserStory,
       ),
     );
+
+    this.requirementIdService.updateRequirementCounters({
+      [REQUIREMENT_TYPE.TASK]: nextTaskId - 1,
+    });
+
     setTimeout(() => {
       this.getLatestUserStories();
       this.loadingService.setLoading(false);

--- a/ui/src/app/pages/tasks/task-list/task-list.component.ts
+++ b/ui/src/app/pages/tasks/task-list/task-list.component.ts
@@ -227,9 +227,11 @@ export class TaskListComponent implements OnInit, OnDestroy {
       ),
     );
 
-    this.requirementIdService.updateRequirementCounters({
-      [REQUIREMENT_TYPE.TASK]: nextTaskId - 1,
-    });
+    this.requirementIdService
+      .updateRequirementCounters({
+        [REQUIREMENT_TYPE.TASK]: nextTaskId - 1,
+      })
+      .then();
 
     setTimeout(() => {
       this.getLatestUserStories();

--- a/ui/src/app/pages/user-stories/user-stories.component.ts
+++ b/ui/src/app/pages/user-stories/user-stories.component.ts
@@ -46,12 +46,14 @@ import { BadgeComponent } from '../../components/core/badge/badge.component';
 import { ConfirmationDialogComponent } from 'src/app/components/confirmation-dialog/confirmation-dialog.component';
 import {
   CONFIRMATION_DIALOG,
+  REQUIREMENT_TYPE,
   TOASTER_MESSAGES,
 } from '../../constants/app.constants';
 import { SearchInputComponent } from '../../components/core/search-input/search-input.component';
 import { SearchService } from '../../services/search/search.service';
 import { BehaviorSubject } from 'rxjs';
 import { ExportFileFormat } from 'src/app/constants/export.constants';
+import { RequirementIdService } from 'src/app/services/requirement-id.service';
 
 @Component({
   selector: 'app-user-stories',
@@ -127,6 +129,7 @@ export class UserStoriesComponent implements OnInit {
     private jiraService: JiraService,
     private electronService: ElectronService,
     private toast: ToasterService,
+    private requirementIdService: RequirementIdService,
   ) {
     this.navigation = getNavigationParams(this.router.getCurrentNavigation());
     this.store.dispatch(
@@ -315,13 +318,36 @@ export class UserStoriesComponent implements OnInit {
     userStories: IUserStory[],
     regenerate: boolean = false,
   ) {
+    const nextIds = {
+      story: this.requirementIdService.getNextRequirementId(
+        REQUIREMENT_TYPE.US,
+      ),
+      task: this.requirementIdService.getNextRequirementId(
+        REQUIREMENT_TYPE.TASK,
+      ),
+    };
+
+    const processedUserStories = userStories.map((userStory) => ({
+      ...userStory,
+      id: `US${nextIds.story++}`,
+      tasks: userStory.tasks?.map((task) => ({
+        ...task,
+        id: `TASK${nextIds.task++}`,
+      })),
+    }));
+
     this.store.dispatch(
       new CreateFile(
         `${this.navigation.folderName}`,
-        { features: userStories },
+        { features: processedUserStories },
         this.navigation.fileName.replace(/\-base.json$/, ''),
       ),
     );
+
+    this.requirementIdService.updateRequirementCounters({
+      [REQUIREMENT_TYPE.US]: nextIds.story - 1,
+      [REQUIREMENT_TYPE.TASK]: --nextIds.task - 1,
+    });
 
     setTimeout(() => {
       this.getLatestUserStories();

--- a/ui/src/app/pages/user-stories/user-stories.component.ts
+++ b/ui/src/app/pages/user-stories/user-stories.component.ts
@@ -344,10 +344,12 @@ export class UserStoriesComponent implements OnInit {
       ),
     );
 
-    this.requirementIdService.updateRequirementCounters({
-      [REQUIREMENT_TYPE.US]: nextIds.story - 1,
-      [REQUIREMENT_TYPE.TASK]: --nextIds.task - 1,
-    });
+    this.requirementIdService
+      .updateRequirementCounters({
+        [REQUIREMENT_TYPE.US]: nextIds.story - 1,
+        [REQUIREMENT_TYPE.TASK]: nextIds.task - 1,
+      })
+      .then();
 
     setTimeout(() => {
       this.getLatestUserStories();

--- a/ui/src/app/services/app-system/app-system.service.ts
+++ b/ui/src/app/services/app-system/app-system.service.ts
@@ -55,6 +55,13 @@ export class AppSystemService {
     });
   }
 
+  async getBaseFileCount(relativePath: string) {
+    const directory = localStorage.getItem(APP_CONSTANTS.WORKING_DIR);
+    return await this.electronService.invokeFunction('getBaseFileCount', {
+      path: `${directory}/${relativePath}`,
+    });
+  }
+
   async createNewFile(
     relativePathWithFileName: string,
     content: any,

--- a/ui/src/app/services/app-system/app-system.service.ts
+++ b/ui/src/app/services/app-system/app-system.service.ts
@@ -59,12 +59,14 @@ export class AppSystemService {
     relativePathWithFileName: string,
     content: any,
     featureFile: string,
-  ) {
+    baseFileCount: number,
+  ): Promise<number> {
     const directory = localStorage.getItem(APP_CONSTANTS.WORKING_DIR);
-    await this.electronService.invokeFunction('appendFile', {
+    return await this.electronService.invokeFunction('appendFile', {
       content,
       path: `${directory}/${relativePathWithFileName}`,
       featureFile,
+      baseFileCount,
     });
   }
 

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngxs/store';
+import { ProjectsState } from '../store/projects/projects.state';
+import { UpdateMetadata } from '../store/projects/projects.actions';
+import { REQUIREMENT_TYPE, RequirementType } from '../constants/app.constants';
+import { IProjectMetadata } from '../model/interfaces/projects.interface';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RequirementIdService {
+  constructor(private store: Store) {}
+
+  public getNextRequirementId(
+    requirementType: RequirementType,
+    autoIncrement = false,
+  ): number {
+    const metadata = this.getMetadata();
+
+    const currentId = metadata.requirementsIdCounter[requirementType] ?? 0;
+    const nextRequirementId = currentId + 1;
+
+    if (autoIncrement) {
+      this.updateRequirementCounters({ [requirementType]: nextRequirementId });
+    }
+
+    return nextRequirementId;
+  }
+
+  public updateRequirementCounters(
+    requirementCounters: Partial<Record<RequirementType, number>>,
+  ): void {
+    const metadata = this.getMetadata();
+
+    this.store.dispatch(
+      new UpdateMetadata(metadata.id, {
+        ...metadata,
+        requirementsIdCounter: {
+          ...metadata.requirementsIdCounter,
+          ...requirementCounters,
+        },
+      }),
+    );
+  }
+
+  private getMetadata(): Omit<IProjectMetadata, 'requirementsIdCounter'> & {
+    requirementsIdCounter: Record<RequirementType, number>;
+  } {
+    const metadata = this.store.selectSnapshot(ProjectsState.getMetadata);
+    console.log(metadata);
+
+    return {
+      ...metadata,
+      requirementsIdCounter:
+        metadata.requirementsIdCounter || this.getInitialCounters(),
+    };
+  }
+
+  private getInitialCounters(): Record<RequirementType, number> {
+    return Object.fromEntries(
+      Object.values(REQUIREMENT_TYPE).map((type) => [type, 0]),
+    ) as Record<RequirementType, number>;
+  }
+}

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -2,14 +2,25 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { ProjectsState } from '../store/projects/projects.state';
 import { UpdateMetadata } from '../store/projects/projects.actions';
-import { REQUIREMENT_TYPE, RequirementType } from '../constants/app.constants';
+import {
+  FILTER_STRINGS,
+  REQUIREMENT_TYPE,
+  REQUIREMENT_TYPE_FOLDER_MAP,
+  RequirementType,
+} from '../constants/app.constants';
 import { IProjectMetadata } from '../model/interfaces/projects.interface';
+import { AppSystemService } from './app-system/app-system.service';
+import { NGXLogger } from 'ngx-logger';
 
 @Injectable({
   providedIn: 'root',
 })
 export class RequirementIdService {
-  constructor(private store: Store) {}
+  constructor(
+    private store: Store,
+    private readonly appSystemService: AppSystemService,
+    private readonly logger: NGXLogger,
+  ) {}
 
   public getNextRequirementId(
     requirementType: RequirementType,
@@ -47,14 +58,125 @@ export class RequirementIdService {
     const metadata = this.store.selectSnapshot(ProjectsState.getMetadata);
     return {
       ...metadata,
-      requirementsIdCounter:
-        metadata.requirementsIdCounter || this.getInitialCounters(),
+      requirementsIdCounter: metadata.requirementsIdCounter || {},
     };
   }
 
-  private getInitialCounters(): Record<RequirementType, number> {
-    return Object.fromEntries(
-      Object.values(REQUIREMENT_TYPE).map((type) => [type, 0]),
-    ) as Record<RequirementType, number>;
+  public async updateFeatureAndTaskIds(
+    projectName: string,
+    idTypes: RequirementType[],
+  ): Promise<{ storyIdCounter: number; taskIdCounter: number }> {
+    try {
+      const prdFeatureFolder = await this.getPrdFeatureFolder(projectName);
+      if (!prdFeatureFolder?.children?.length) {
+        throw new Error(`No PRD files found for project: ${projectName}`);
+      }
+
+      const prdFolderPath = `${projectName}/${REQUIREMENT_TYPE_FOLDER_MAP[REQUIREMENT_TYPE.PRD]}`;
+      let storyIdCounter = 1;
+      let taskIdCounter = 1;
+
+      // First pass: update IDs for stories or tasks
+      const fileContents = await Promise.all(
+        prdFeatureFolder.children.map(async (fileName) => {
+          const filePath = `${prdFolderPath}/${fileName}`;
+          try {
+            const fileContent = await this.appSystemService.readFile(filePath);
+            const parsedContent = JSON.parse(fileContent);
+
+            if (parsedContent.features?.length) {
+              parsedContent.features.forEach((story: any) => {
+                if (idTypes.includes(REQUIREMENT_TYPE.US)) {
+                  story.id = `US${storyIdCounter++}`;
+                }
+                if (
+                  idTypes.includes(REQUIREMENT_TYPE.TASK) &&
+                  story.tasks?.length
+                ) {
+                  story.tasks.forEach((task: any) => {
+                    task.id = `TASK${taskIdCounter++}`;
+                  });
+                }
+              });
+
+              return { filePath, content: parsedContent };
+            }
+          } catch (error) {
+            this.logger.error(
+              `Failed to read or process file ${fileName} for project: ${projectName}`,
+              error,
+            );
+          }
+          return null;
+        }),
+      );
+
+      // Second pass: write updated files
+      const validFileContents = fileContents.filter(
+        (item): item is { filePath: string; content: any } => item !== null,
+      );
+      await Promise.all(
+        validFileContents.map(async ({ filePath, content }) => {
+          try {
+            await this.appSystemService.createFileWithContent(
+              filePath,
+              JSON.stringify(content),
+            );
+          } catch (error) {
+            this.logger.error(
+              `Failed to write file ${filePath} for project: ${projectName}`,
+              error,
+            );
+          }
+        }),
+      );
+
+      return { storyIdCounter, taskIdCounter };
+    } catch (error) {
+      this.logger.error(
+        `Failed to update IDs for project: ${projectName}`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  private async getPrdFeatureFolder(
+    projectName: string,
+  ): Promise<{ name: string; children?: string[] } | undefined> {
+    const projectFolders = await this.appSystemService.getFolders(
+      projectName,
+      FILTER_STRINGS.FEATURE,
+    );
+
+    return projectFolders.find(
+      (folder: { name: string; children?: string[] }) =>
+        folder.name === REQUIREMENT_TYPE_FOLDER_MAP[REQUIREMENT_TYPE.PRD],
+    );
+  }
+
+  public async syncStoryAndTaskCounters(): Promise<void> {
+    const project = this.store.selectSnapshot(ProjectsState.getSelectedProject);
+
+    const missingCounters = [
+      this.isCounterMissing(REQUIREMENT_TYPE.US) && REQUIREMENT_TYPE.US,
+      this.isCounterMissing(REQUIREMENT_TYPE.TASK) && REQUIREMENT_TYPE.TASK,
+    ].filter(Boolean) as RequirementType[];
+
+    if (missingCounters.length > 0) {
+      const { storyIdCounter, taskIdCounter } =
+        await this.updateFeatureAndTaskIds(project, missingCounters);
+
+      this.updateRequirementCounters({
+        [REQUIREMENT_TYPE.US]: storyIdCounter - 1,
+        [REQUIREMENT_TYPE.TASK]: taskIdCounter - 1,
+      });
+    }
+  }
+
+  private isCounterMissing(type: RequirementType): boolean {
+    const metadata = this.store.selectSnapshot(ProjectsState.getMetadata);
+    const { requirementsIdCounter = {} } = metadata;
+    return requirementsIdCounter[type] === undefined;
   }
 }

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -47,8 +47,6 @@ export class RequirementIdService {
     requirementsIdCounter: Record<RequirementType, number>;
   } {
     const metadata = this.store.selectSnapshot(ProjectsState.getMetadata);
-    console.log(metadata);
-
     return {
       ...metadata,
       requirementsIdCounter:

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -26,7 +26,7 @@ export class RequirementIdService {
 
   public getNextRequirementId(requirementType: RequirementType): number {
     const metadata = this.getMetadata();
-    const currentId = metadata[requirementType]?.counter ?? 0;
+    const currentId = metadata[requirementType]?.count ?? 0;
     const nextRequirementId = currentId + 1;
 
     return nextRequirementId;
@@ -41,7 +41,7 @@ export class RequirementIdService {
         ...acc,
         [type]: {
           ...metadata[type as RequirementType],
-          counter: count,
+          count: count,
         },
       }),
       {},
@@ -188,7 +188,7 @@ export class RequirementIdService {
 
   public isCounterMissing(type: RequirementType): boolean {
     const metadata = this.getMetadata();
-    return !metadata[type] || metadata[type].counter === undefined;
+    return !metadata[type] || metadata[type].count === undefined;
   }
 
   private async getMissingRootRequirementCounters(
@@ -197,7 +197,7 @@ export class RequirementIdService {
     const metadata = this.getMetadata();
     const folders = Object.values(FOLDER).filter((folder) => {
       const data = metadata[folder as RequirementType];
-      return !data || data.counter === undefined;
+      return !data || data.count === undefined;
     });
 
     if (!folders.length) return {};

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -166,12 +166,17 @@ export class RequirementIdService {
       const { storyIdCounter, taskIdCounter } =
         await this.updateFeatureAndTaskIds(project, missingCounters);
 
-      await this.updateRequirementCounters({
-        [REQUIREMENT_TYPE.US]: storyIdCounter - 1,
-        [REQUIREMENT_TYPE.TASK]: taskIdCounter - 1,
-      });
+      const countersToUpdate = Object.fromEntries(
+        missingCounters.map((type) => [
+          type,
+          type === REQUIREMENT_TYPE.US ? storyIdCounter - 1 : taskIdCounter - 1,
+        ]),
+      );
+
+      await this.updateRequirementCounters(countersToUpdate);
     }
   }
+
   public async syncRootRequirementCounters(projectName: string): Promise<void> {
     const missingCounters =
       await this.getMissingRootRequirementCounters(projectName);

--- a/ui/src/app/services/requirement-id.service.ts
+++ b/ui/src/app/services/requirement-id.service.ts
@@ -43,9 +43,7 @@ export class RequirementIdService {
     );
   }
 
-  private getMetadata(): Omit<IProjectMetadata, 'requirementsIdCounter'> & {
-    requirementsIdCounter: Record<RequirementType, number>;
-  } {
+  private getMetadata(): IProjectMetadata {
     const metadata = this.store.selectSnapshot(ProjectsState.getMetadata);
     return {
       ...metadata,

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -186,8 +186,12 @@ export class ProjectsState {
         }),
       );
 
+      const { requirementsPreferences, ...metadataWithoutPreferences } =
+        metadata;
+
       metadata = {
-        ...metadata,
+        ...metadataWithoutPreferences,
+        ...(!metadata.cleanSolution && { requirementsPreferences }),
         requirementsIdCounter: {
           BRD: response?.brd?.length || 0,
           PRD: response?.prd?.length || 0,

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -32,6 +32,7 @@ import {
 } from 'src/app/constants/app.constants';
 import { RequirementTypeEnum } from 'src/app/model/enum/requirement-type.enum';
 import { RequirementExportService } from 'src/app/services/export/requirement-export.service';
+import { RequirementIdService } from 'src/app/services/requirement-id.service';
 
 export class ProjectStateModel {
   projects!: IProject[];
@@ -76,6 +77,7 @@ export class ProjectsState {
     private router: Router,
     private toast: ToasterService,
     private requirementExportService: RequirementExportService,
+    private requirementIdService: RequirementIdService,
   ) {}
 
   @Selector()
@@ -297,6 +299,10 @@ export class ProjectsState {
             (indexB === -1 ? Number.MAX_SAFE_INTEGER : indexB)
           );
         },
+      );
+
+      await this.requirementIdService.syncRootRequirementCounters(
+        project.project,
       );
 
       patchState({

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -205,8 +205,8 @@ export class ProjectsState {
           (acc, [_, type]) => ({
             ...acc,
             [type]: metadata.cleanSolution
-              ? { counter: 0 }
-              : { ...metadata[type], counter: responseMap[type] },
+              ? { count: 0 }
+              : { ...metadata[type], count: responseMap[type] },
           }),
           {},
         ),
@@ -500,7 +500,7 @@ export class ProjectsState {
       `${state.selectedProject}/${path}`,
       fileContent,
       featureFile,
-      state.metadata?.[path]?.counter || -1,
+      state.metadata?.[path]?.count || -1,
     );
 
     if (!featureFile) {
@@ -523,7 +523,7 @@ export class ProjectsState {
       ...state.metadata,
       [path]: {
         ...state.metadata[path],
-        counter: baseFileCount + 1,
+        count: baseFileCount + 1,
       },
     };
 

--- a/ui/src/app/store/user-stories/user-stories.state.ts
+++ b/ui/src/app/store/user-stories/user-stories.state.ts
@@ -273,8 +273,11 @@ export class UserStoriesState {
 
     const nextStoryId = this.requirementIdService.getNextRequirementId(
       REQUIREMENT_TYPE.US,
-      true,
     );
+
+    await this.requirementIdService.updateRequirementCounters({
+      [REQUIREMENT_TYPE.US]: nextStoryId,
+    });
 
     const newUserStory = { id: `US${nextStoryId}`, ...userStory, tasks: [] };
     const updatedUserStories = [...state.userStories, newUserStory];

--- a/ui/src/app/store/user-stories/user-stories.state.ts
+++ b/ui/src/app/store/user-stories/user-stories.state.ts
@@ -22,6 +22,7 @@ import { Router } from '@angular/router';
 import { RequirementExportService } from 'src/app/services/export/requirement-export.service';
 import { REQUIREMENT_TYPE } from 'src/app/constants/app.constants';
 import { ToasterService } from 'src/app/services/toaster/toaster.service';
+import { RequirementIdService } from 'src/app/services/requirement-id.service';
 
 export interface UserStoriesStateModel {
   userStories: IUserStory[];
@@ -58,8 +59,9 @@ export class UserStoriesState {
     private logger: NGXLogger,
     private router: Router,
     private toast: ToasterService,
-    private requirementExportService: RequirementExportService
-  ) { }
+    private requirementExportService: RequirementExportService,
+    private requirementIdService: RequirementIdService,
+  ) {}
 
   @Selector()
   static getUserStories(state: UserStoriesStateModel) {
@@ -268,9 +270,12 @@ export class UserStoriesState {
   ) {
     const state = ctx.getState();
 
-    const newId = `US${state.userStories.length + 1}`;
+    const nextStoryId = this.requirementIdService.getNextRequirementId(
+      REQUIREMENT_TYPE.US,
+      true,
+    );
 
-    const newUserStory = { id: newId, ...userStory, tasks: [] };
+    const newUserStory = { id: `US${nextStoryId}`, ...userStory, tasks: [] };
     const updatedUserStories = [...state.userStories, newUserStory];
 
     const fileContent = JSON.stringify(


### PR DESCRIPTION
### Description

This PR improves the requirement ID generation system by implementing type-wise counters (e.g., BRD, US, TASK, PRD) at the solution level.  

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)  
- [ ] ✨ New feature (non-breaking change which adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

- [x] Changes are limited to a single feature, bugfix, or chore (split larger changes into separate PRs)  
- [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)
