### PR TITLE
fix: add instruction in requirement update prompt to output only single requirement

### DIFF
--- a/.changeset/eager-facts-flash.md
+++ b/.changeset/eager-facts-flash.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+add instruction in requirement update prompt to output only single requirement

--- a/backend/llm/prompts/02_update.jinja2
+++ b/backend/llm/prompts/02_update.jinja2
@@ -43,7 +43,9 @@ Output Structure MUST be a valid JSON: Here is the sample Structure:
 }
 
 Special Instructions:
-1. You are allowed to use for the updated requirement description. You MUST ONLY use valid Markdown according to the following rules:
+(!) You are allowed to use for the updated requirement description. You MUST ONLY use valid Markdown according to the following rules:
     {% include 'markdown_rules.jinja2' %}
+(!) The output MUST be a valid JSON object strictly adhering to the structure defined above. Failure to produce valid JSON will cause a critical application error. 
+    The value of the updated key MUST represent one requirement (and absolutely NOT an array of requirements)
 
 Output only valid JSON. Do not include ```json ``` on start and end of the response.

--- a/ui/src/app/components/document-listing/document-listing.component.ts
+++ b/ui/src/app/components/document-listing/document-listing.component.ts
@@ -3,10 +3,7 @@ import { Store } from '@ngxs/store';
 import { ProjectsState } from '../../store/projects/projects.state';
 import { BehaviorSubject, combineLatest, Observable, Subscription, first } from 'rxjs';
 import { BulkReadFiles, ExportRequirementData } from '../../store/projects/projects.actions';
-import {
-  getDescriptionFromInput,
-  truncateWithEllipsis,
-} from '../../utils/common.utils';
+import { getDescriptionFromInput } from '../../utils/common.utils';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { IList } from '../../model/interfaces/IList';


### PR DESCRIPTION
add instruction in requirement update prompt to output only single requirement

### Description

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

LLM was returning array of requirements sometimes instead of single requirement causing the title and requirement to get assigned undefined.
