### PR TITLE
fix: subscribe to current user story in add-task component

### DIFF
--- a/.changeset/puny-ends-trade.md
+++ b/.changeset/puny-ends-trade.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix unable to update/ add task with ai

--- a/ui/src/app/pages/tasks/add-task/add-task.component.ts
+++ b/ui/src/app/pages/tasks/add-task/add-task.component.ts
@@ -138,6 +138,11 @@ export class AddTaskComponent implements OnDestroy {
       this.prd = res;
     });
 
+    this.store
+      .select(UserStoriesState.getSelectedUserStory)
+      .subscribe((res) => {
+        this.userStory = res;
+      });
 
     this.createTaskForm(taskId);
     this.editLabel = this.mode == 'edit' ? 'Edit' : 'Add';


### PR DESCRIPTION
### Description

subscribe to current user story in add-task component without this the add/ update task with ai is failing.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)
