### PR TITLE
chore: update database schema with new tables and common columns for improved structure

### DIFF
--- a/electron/db/schema.ts
+++ b/electron/db/schema.ts
@@ -3,24 +3,30 @@ import {
   text,
   integer,
   primaryKey,
-  unique,
 } from "drizzle-orm/sqlite-core";
+
+export const docTypeEnum = ["PRD", "BRD"] as const;
+export type DocType = (typeof docTypeEnum)[number];
+
+export const commonColumns = {
+  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
+  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  isDeleted: integer("is_deleted", { mode: "boolean" }).default(false),
+};
 
 export const metadata = sqliteTable("Metadata", {
   id: integer("id").primaryKey(),
   name: text("name").notNull(),
   description: text("description"),
-  techStacks: text("tech_stacks"),
+  techStacks: text("technical_details"),
   isBrownfield: integer("is_brownfield", { mode: "boolean" }).default(false),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
 export const integration = sqliteTable("Integration", {
   id: integer("id").primaryKey(),
   config: text("config"),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
 export const documentType = sqliteTable("DocumentType", {
@@ -28,8 +34,7 @@ export const documentType = sqliteTable("DocumentType", {
   name: text("name").notNull(),
   typeLabel: text("type_label"),
   isActive: integer("is_active", { mode: "boolean" }).default(true),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
 export const document = sqliteTable("Document", {
@@ -40,12 +45,8 @@ export const document = sqliteTable("Document", {
   documentTypeId: text("document_type_id")
     .notNull()
     .references(() => documentType.id, { onDelete: "set null" }),
-  metadataId: integer("metadata_id")
-    .notNull()
-    .references(() => metadata.id, { onDelete: "cascade" }),
   count: integer("count").default(0),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
 export const conversation = sqliteTable("Conversation", {
@@ -54,8 +55,7 @@ export const conversation = sqliteTable("Conversation", {
     .notNull()
     .references(() => document.id, { onDelete: "cascade" }),
   title: text("title"),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
 export const message = sqliteTable("Message", {
@@ -64,33 +64,33 @@ export const message = sqliteTable("Message", {
     .notNull()
     .references(() => conversation.id, { onDelete: "cascade" }),
   message: text("message").notNull(),
+  role: text("role").notNull(),
   isApplied: integer("is_applied", { mode: "boolean" }).default(false),
-  externalMessageId: text("external_message_id"),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
-export const businessFlow = sqliteTable("BusinessFlow", {
+export const businessProcess = sqliteTable("BusinessProcess", {
   id: integer("id").primaryKey(),
   name: text("name").notNull(),
   description: text("description"),
   flowchart: text("flowchart"),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });
 
-export const businessFlowDocuments = sqliteTable(
-  "BusinessFlow_Documents",
+export const businessProcessDocuments = sqliteTable(
+  "BusinessProcessDocuments",
   {
-    businessFlowId: integer("business_flow_id")
+    businessProcessId: integer("business_process_id")
       .notNull()
-      .references(() => businessFlow.id, { onDelete: "cascade" }),
+      .references(() => businessProcess.id, { onDelete: "cascade" }),
     documentId: integer("document_id")
       .notNull()
       .references(() => document.id, { onDelete: "cascade" }),
-    docType: text("doc_type", { enum: ["PRD", "BRD"] }).notNull(),
+    docType: text("doc_type", { enum: docTypeEnum }).notNull(),
   },
-  (t) => [primaryKey({ columns: [t.businessFlowId, t.documentId, t.docType] })]
+  (t) => [
+    primaryKey({ columns: [t.businessProcessId, t.documentId, t.docType] }),
+  ]
 );
 
 export const analyticsLookup = sqliteTable("AnalyticsLookup", {
@@ -98,6 +98,5 @@ export const analyticsLookup = sqliteTable("AnalyticsLookup", {
   targetType: text("target_type").notNull(),
   targetId: integer("target_id").notNull(),
   isLiked: integer("is_liked", { mode: "boolean" }).default(false),
-  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
-  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+  ...commonColumns,
 });

--- a/electron/drizzle/0001_slim_talisman.sql
+++ b/electron/drizzle/0001_slim_talisman.sql
@@ -1,0 +1,43 @@
+ALTER TABLE `BusinessFlow` RENAME TO `BusinessProcess`;--> statement-breakpoint
+ALTER TABLE `BusinessFlow_Documents` RENAME TO `BusinessProcessDocuments`;--> statement-breakpoint
+ALTER TABLE `BusinessProcessDocuments` RENAME COLUMN "business_flow_id" TO "business_process_id";--> statement-breakpoint
+ALTER TABLE `Metadata` RENAME COLUMN "tech_stacks" TO "technical_details";--> statement-breakpoint
+ALTER TABLE `BusinessProcess` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_BusinessProcessDocuments` (
+	`business_process_id` integer NOT NULL,
+	`document_id` integer NOT NULL,
+	`doc_type` text NOT NULL,
+	PRIMARY KEY(`business_process_id`, `document_id`, `doc_type`),
+	FOREIGN KEY (`business_process_id`) REFERENCES `BusinessProcess`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`document_id`) REFERENCES `Document`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_BusinessProcessDocuments`("business_process_id", "document_id", "doc_type") SELECT "business_process_id", "document_id", "doc_type" FROM `BusinessProcessDocuments`;--> statement-breakpoint
+DROP TABLE `BusinessProcessDocuments`;--> statement-breakpoint
+ALTER TABLE `__new_BusinessProcessDocuments` RENAME TO `BusinessProcessDocuments`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+ALTER TABLE `Metadata` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+CREATE TABLE `__new_Document` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`jira_id` text,
+	`document_type_id` text NOT NULL,
+	`count` integer DEFAULT 0,
+	`created_at` text DEFAULT 'CURRENT_TIMESTAMP',
+	`updated_at` text DEFAULT 'CURRENT_TIMESTAMP',
+	`is_deleted` integer DEFAULT false,
+	FOREIGN KEY (`document_type_id`) REFERENCES `DocumentType`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT INTO `__new_Document`("id", "name", "description", "jira_id", "document_type_id", "count", "created_at", "updated_at", "is_deleted") SELECT "id", "name", "description", "jira_id", "document_type_id", "count", "created_at", "updated_at", "is_deleted" FROM `Document`;--> statement-breakpoint
+DROP TABLE `Document`;--> statement-breakpoint
+ALTER TABLE `__new_Document` RENAME TO `Document`;--> statement-breakpoint
+ALTER TABLE `AnalyticsLookup` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `Conversation` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `DocumentType` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `Integration` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `Message` ADD `role` text NOT NULL;--> statement-breakpoint
+ALTER TABLE `Message` ADD `is_deleted` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `Message` DROP COLUMN `external_message_id`;

--- a/electron/drizzle/meta/0001_snapshot.json
+++ b/electron/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,641 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "432b2f0d-2587-4719-bcc2-47c986123a24",
+  "prevId": "4a85ea4b-d464-4a29-8929-efeeb6847035",
+  "tables": {
+    "AnalyticsLookup": {
+      "name": "AnalyticsLookup",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_liked": {
+          "name": "is_liked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "BusinessProcess": {
+      "name": "BusinessProcess",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flowchart": {
+          "name": "flowchart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "BusinessProcessDocuments": {
+      "name": "BusinessProcessDocuments",
+      "columns": {
+        "business_process_id": {
+          "name": "business_process_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc_type": {
+          "name": "doc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "BusinessProcessDocuments_business_process_id_BusinessProcess_id_fk": {
+          "name": "BusinessProcessDocuments_business_process_id_BusinessProcess_id_fk",
+          "tableFrom": "BusinessProcessDocuments",
+          "tableTo": "BusinessProcess",
+          "columnsFrom": [
+            "business_process_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "BusinessProcessDocuments_document_id_Document_id_fk": {
+          "name": "BusinessProcessDocuments_document_id_Document_id_fk",
+          "tableFrom": "BusinessProcessDocuments",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "BusinessProcessDocuments_business_process_id_document_id_doc_type_pk": {
+          "columns": [
+            "business_process_id",
+            "document_id",
+            "doc_type"
+          ],
+          "name": "BusinessProcessDocuments_business_process_id_document_id_doc_type_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Conversation": {
+      "name": "Conversation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Conversation_document_id_Document_id_fk": {
+          "name": "Conversation_document_id_Document_id_fk",
+          "tableFrom": "Conversation",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Document": {
+      "name": "Document",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "jira_id": {
+          "name": "jira_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_type_id": {
+          "name": "document_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_document_type_id_DocumentType_id_fk": {
+          "name": "Document_document_type_id_DocumentType_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "DocumentType",
+          "columnsFrom": [
+            "document_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "DocumentType": {
+      "name": "DocumentType",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type_label": {
+          "name": "type_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Integration": {
+      "name": "Integration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Message": {
+      "name": "Message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_applied": {
+          "name": "is_applied",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_conversation_id_Conversation_id_fk": {
+          "name": "Message_conversation_id_Conversation_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "Metadata": {
+      "name": "Metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "technical_details": {
+          "name": "technical_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_brownfield": {
+          "name": "is_brownfield",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'CURRENT_TIMESTAMP'"
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {
+      "\"BusinessFlow\"": "\"BusinessProcess\"",
+      "\"BusinessFlow_Documents\"": "\"BusinessProcessDocuments\""
+    },
+    "columns": {
+      "\"BusinessProcessDocuments\".\"business_flow_id\"": "\"BusinessProcessDocuments\".\"business_process_id\"",
+      "\"Metadata\".\"tech_stacks\"": "\"Metadata\".\"technical_details\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/electron/drizzle/meta/_journal.json
+++ b/electron/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1744178573720,
       "tag": "0000_dusty_mother_askani",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1744191575202,
+      "tag": "0001_slim_talisman",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
### Description

Updated the Drizzle schema to include new tables and standardised common columns (e.g., `createdAt`, `updatedAt`, `isDeleted`). This improves consistency and scalability across the backend database structure.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)  
-   [x] ✨ New feature (non-breaking change which adds functionality)  
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] 📚 Documentation update  

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)  
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)  
