### PR TITLE
fix: prevent solution creation when cleanSolution is true

### DIFF
--- a/.changeset/clear-crews-drum.md
+++ b/.changeset/clear-crews-drum.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix: prevent solution creation when cleanSolution is true

--- a/electron/api/solution/create.ts
+++ b/electron/api/solution/create.ts
@@ -110,6 +110,17 @@ export async function createSolution(event: IpcMainInvokeEvent, data: unknown): 
     const validationSpan = trace.span({name: "input-validation"})
     const validatedData = await createSolutionSchema.parseAsync(data);
     validationSpan.end();
+
+    const results: SolutionResponse = {
+      createReqt: validatedData.createReqt ?? false,
+      description: validatedData.description,
+      name: validatedData.name
+    };
+
+    if (!validatedData.createReqt) {
+      return results;
+    }
+
     
     const useAgent = true;
 
@@ -187,12 +198,6 @@ export async function createSolution(event: IpcMainInvokeEvent, data: unknown): 
         }, {}),
       };
     }
-
-    const results: SolutionResponse = {
-      createReqt: validatedData.createReqt ?? false,
-      description: validatedData.description,
-      name: validatedData.name
-    };
 
     const llmHandler = buildLLMHandler(
       llmConfig.activeProvider,

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -122,7 +122,8 @@
                     <app-toggle
                       [isActive]="solutionForm.get('cleanSolution')?.value"
                       (toggleChange)="
-                        solutionForm.get('cleanSolution')?.setValue($event)
+                        solutionForm.get('cleanSolution')?.setValue($event);
+                        solutionForm.get('createReqt')?.setValue(!($event));
                       "
                       isPlainToggle="true"
                     ></app-toggle>

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -122,8 +122,7 @@
                     <app-toggle
                       [isActive]="solutionForm.get('cleanSolution')?.value"
                       (toggleChange)="
-                        solutionForm.get('cleanSolution')?.setValue($event);
-                        solutionForm.get('createReqt')?.setValue(!($event));
+                        solutionForm.get('cleanSolution')?.setValue($event)
                       "
                       isPlainToggle="true"
                     ></app-toggle>

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -97,7 +97,6 @@ export class CreateSolutionComponent implements OnInit {
         Validators.required,
         Validators.pattern(/\S/),
       ]),
-      createReqt: new FormControl(true),
       id: new FormControl(uuid()),
       createdAt: new FormControl(new Date().toISOString()),
       cleanSolution: new FormControl(false),
@@ -138,6 +137,7 @@ export class CreateSolutionComponent implements OnInit {
     ) {
       this.addOrUpdate = true;
       const data = this.solutionForm.getRawValue();
+      data.createReqt = !data.cleanSolution;
       this.store.dispatch(new CreateProject(data.name, data));
     }
   }


### PR DESCRIPTION
### Description

Fixed a bug where solutions were being created even when the `cleanSolution` toggle was enabled. The toggle logic has been updated to respect the `cleanSolution` flag and prevent unintended creation.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

