### PR TITLE
fix: reset form state to prevent redirect issue on add

### DIFF
--- a/.changeset/orange-cameras-throw.md
+++ b/.changeset/orange-cameras-throw.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix: Resolved an issue where adding new requirements triggered an unintended discard popup.

--- a/ui/src/app/pages/business-process/business-process.component.ts
+++ b/ui/src/app/pages/business-process/business-process.component.ts
@@ -228,6 +228,8 @@ export class BusinessProcessComponent implements OnInit {
         chatHistory: this.chatHistory,
       }),
     );
+    this.businessProcessForm.markAsUntouched();
+    this.businessProcessForm.markAsPristine();
     this.navigateBackToDocumentList(this.data);
     this.toastService.showSuccess(
       TOASTER_MESSAGES.ENTITY.ADD.SUCCESS(this.folderName),

--- a/ui/src/app/pages/edit-solution/edit-solution.component.ts
+++ b/ui/src/app/pages/edit-solution/edit-solution.component.ts
@@ -452,6 +452,8 @@ export class EditSolutionComponent {
           }
 
           this.store.dispatch(new CreateFile(`${this.folderName}`, fileData));
+          this.requirementForm.markAsPristine();
+          this.requirementForm.markAsUntouched();          
           this.navigateBackToDocumentList(this.initialData);
           this.toastService.showSuccess(
             TOASTER_MESSAGES.ENTITY.ADD.SUCCESS(this.folderName),
@@ -476,6 +478,8 @@ export class EditSolutionComponent {
       }
 
       this.store.dispatch(new CreateFile(`${this.folderName}`, fileData));
+      this.requirementForm.markAsPristine();
+      this.requirementForm.markAsUntouched();          
       this.navigateBackToDocumentList(this.initialData);
       this.toastService.showSuccess(
         TOASTER_MESSAGES.ENTITY.ADD.SUCCESS(this.folderName),

--- a/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
+++ b/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
@@ -285,6 +285,8 @@ export class EditUserStoriesComponent implements OnDestroy {
                 this.absoluteFilePath,
               ),
             );
+            this.userStoryForm.markAsPristine();
+            this.userStoryForm.markAsUntouched();
             this.navigateBackToUserStories();
             this.toasterService.showSuccess(
               TOASTER_MESSAGES.ENTITY.ADD.SUCCESS(this.entityType),
@@ -310,6 +312,8 @@ export class EditUserStoriesComponent implements OnDestroy {
           this.absoluteFilePath,
         ),
       );
+      this.userStoryForm.markAsPristine();
+      this.userStoryForm.markAsUntouched();
       this.navigateBackToUserStories();
       this.toasterService.showSuccess(
         TOASTER_MESSAGES.ENTITY.ADD.SUCCESS(this.entityType),


### PR DESCRIPTION
### Description

Reset `Form` state using `markAsPristine()` and `markAsUntouched()` to ensure that `dirty && touched` checks return false after form submission. This prevents an unintended discard popup when adding.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)  
-   [ ] ✨ New feature (non-breaking change which adds functionality)  
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] 📚 Documentation update  

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)  
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)  

