### PR TITLE
feat(select): add clear button to select component

### DIFF
--- a/.changeset/lemon-donkeys-create.md
+++ b/.changeset/lemon-donkeys-create.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+feat(select): add clear button to select component

--- a/ui/src/app/components/core/app-select/app-select.component.html
+++ b/ui/src/app/components/core/app-select/app-select.component.html
@@ -32,6 +32,15 @@
       </div>
     </ng-template>
 
+    <!-- Cross Button -->
+    <button
+      *ngIf="clearable && selectedOption"
+      (click)="clear($event)"
+      class="pointer-events-auto absolute inset-y-0 right-8 flex items-center pr-2 cursor-pointer"
+    >
+    <ng-icon name="heroXMark" class="text-secondary-500 h-4 w-4"></ng-icon>
+    </button>
+
     <!-- Dropdown Arrow -->
     <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
       <svg

--- a/ui/src/app/components/core/app-select/app-select.component.ts
+++ b/ui/src/app/components/core/app-select/app-select.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, Output, EventEmitter, forwardRef, HostListener } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
+import { NgIconComponent, provideIcons } from '@ng-icons/core';
+import { heroXMark } from '@ng-icons/heroicons/outline';
 
 export interface SelectOption {
   value: string;
@@ -11,8 +13,9 @@ export interface SelectOption {
   selector: 'app-select',
   templateUrl: './app-select.component.html',
   standalone: true,
-  imports: [NgForOf, NgIf],
+  imports: [NgForOf, NgIf, NgIconComponent],
   providers: [
+    provideIcons({ heroXMark }),
     {
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => AppSelectComponent),
@@ -31,8 +34,9 @@ export class AppSelectComponent implements ControlValueAccessor {
   @Input() customClass: string = '';
   @Input() dropdownClass: string = '';
   @Input() optionClass: string = '';
+  @Input() clearable: boolean = false;
 
-  @Output() selectionChange = new EventEmitter<string>();
+  @Output() selectionChange = new EventEmitter<string | null>();
 
   showDropdown: boolean = false;
   filteredOptions: SelectOption[] = [];
@@ -112,6 +116,14 @@ export class AppSelectComponent implements ControlValueAccessor {
     this.showDropdown = false;
     this.onChange(option.value);
     this.selectionChange.emit(option.value);
+  }
+
+  clear(event: Event): void {
+    event.stopPropagation();
+    this.selectedOption = null;
+    this.searchText = '';
+    this.onChange(null);
+    this.selectionChange.emit(null);
   }
 
   private filterOptions(): void {

--- a/ui/src/app/components/settings/settings.component.html
+++ b/ui/src/app/components/settings/settings.component.html
@@ -36,6 +36,7 @@
                 [options]="providerOptions"
                 [searchable]="true"
                 [required]="true"
+                [clearable]="true"
                 placeholder="Select LLM Provider"
               ></app-select>
             </div>


### PR DESCRIPTION
### Description

Added a "Clear" button to the provider select option on the settings page. This allows users to easily reset their selection without needing to manually deselect or reload the page. 

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)  
-   [x] ✨ New feature (non-breaking change which adds functionality)  
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] 📚 Documentation update  

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)  
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)  

### Screenshots

<!-- For UI changes, add screenshots here -->

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/d031c0b2-5486-470e-968b-0581052721dc) | ![after](https://github.com/user-attachments/assets/00efda22-9623-4bb7-9917-f6a2f06dcfad) |




