### PR TITLE
fix: use shell-path to load PATH env variable from default shell

### DIFF
--- a/electron/mcp/mcp-connection.ts
+++ b/electron/mcp/mcp-connection.ts
@@ -20,7 +20,7 @@ const DEFAULT_MCP_TIMEOUT = 20_000; // 20 seconds
 
 export class MCPConnection {
   public client: Client;
-  private transport: Transport;
+  private transport!: Transport;
 
   private connectionPromise: Promise<unknown> | null = null;
   public abortController: AbortController;
@@ -38,8 +38,6 @@ export class MCPConnection {
     private readonly options: MCPServerOptions,
     metadata: Record<string, any> = {}
   ) {
-    this.transport = this.constructTransport(options);
-
     this.client = new Client({
       name: "specifai-client",
       version: "0.1",
@@ -49,12 +47,17 @@ export class MCPConnection {
     this._metadata = metadata;
   }
 
-  private constructTransport(options: MCPServerOptions): Transport {
+  private async constructTransport(options: MCPServerOptions): Promise<Transport> {
     switch (options.transportType) {
       case "stdio":
         const env: Record<string, string> = options.env || {};
-        if (process.env.PATH !== undefined) {
-          env.PATH = process.env.PATH;
+        // @ts-expect-error shell-path has no type definitions
+        const { shellPath } = await (eval('import("shell-path")') as Promise<typeof import('shell-path')>);
+        const defaultShellPath = await shellPath();
+        // https://github.com/electron/electron/issues/5626
+        // > This is unfortunately a behavior of OS X, every app started from Finder does not get the environment variables from terminal
+        if (defaultShellPath !== undefined) {
+          env.PATH = defaultShellPath;
         }
         return new StdioClientTransport({
           command: options.command,
@@ -236,7 +239,7 @@ export class MCPConnection {
               });
             }),
             (async () => {
-              this.transport = this.constructTransport(this.options);
+              this.transport = await this.constructTransport(this.options);
               try {
                 await this.client.connect(this.transport);
               } catch (error) {

--- a/electron/mcp/mcp-connection.ts
+++ b/electron/mcp/mcp-connection.ts
@@ -20,7 +20,7 @@ const DEFAULT_MCP_TIMEOUT = 20_000; // 20 seconds
 
 export class MCPConnection {
   public client: Client;
-  private transport!: Transport;
+  private transport: Transport | null = null;
 
   private connectionPromise: Promise<unknown> | null = null;
   public abortController: AbortController;

--- a/electron/mcp/mcp-connection.ts
+++ b/electron/mcp/mcp-connection.ts
@@ -52,6 +52,7 @@ export class MCPConnection {
       case "stdio":
         const env: Record<string, string> = options.env || {};
         // @ts-expect-error shell-path has no type definitions
+        // https://github.com/sindresorhus/file-type/issues/535#issuecomment-1065952695
         const { shellPath } = await (eval('import("shell-path")') as Promise<typeof import('shell-path')>);
         const defaultShellPath = await shellPath();
         // https://github.com/electron/electron/issues/5626

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -37,6 +37,7 @@
         "langchain": "^0.3.19",
         "langfuse": "^3.37.0",
         "openai": "^4.87.4",
+        "shell-path": "^3.0.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -6670,6 +6671,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-shell": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz",
+      "integrity": "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -7411,6 +7424,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/exponential-backoff": {
@@ -8229,6 +8277,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -8552,6 +8609,18 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -9368,6 +9437,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9772,6 +9847,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -11362,6 +11449,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-env": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-4.0.1.tgz",
+      "integrity": "sha512-w3oeZ9qg/P6Lu6qqwavvMnB/bwfsz67gPB3WXmLd/n6zuh7TWQZtGa3iMEdmua0kj8rivkwl+vUjgLWlqZOMPw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-shell": "^2.0.0",
+        "execa": "^5.1.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shell-env/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/shell-env/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/shell-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-3.0.0.tgz",
+      "integrity": "sha512-HNIZ+W/3P0JuVTV03xjGqYKt3e3h0/Z4AH8TQWeth1LBtCusSjICgkdNdb3VZr6mI7ijE2AiFFpgkVMNKsALeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-env": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
@@ -11457,7 +11603,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
@@ -11707,6 +11852,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strnum": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -67,6 +67,7 @@
     "langchain": "^0.3.19",
     "langfuse": "^3.37.0",
     "openai": "^4.87.4",
+    "shell-path": "^3.0.0",
     "zod": "^3.24.2"
   },
   "build": {


### PR DESCRIPTION
### Description

uses shell-path to load PATH env variable from default shell

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)