### PR TITLE
feat: switch from max to min requirement count in requirement generation

### DIFF
--- a/.changeset/cute-papers-repair.md
+++ b/.changeset/cute-papers-repair.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+Switched from using `maxRequirementCount` to `minRequirementCount` in requirement generation logic.

--- a/electron/agentic/common/types.ts
+++ b/electron/agentic/common/types.ts
@@ -8,6 +8,6 @@ export type ITool = StructuredToolInterface | DynamicTool | RunnableToolLike;
 
 export type IRequirementItemGenerationPref = {
     isEnabled: boolean;
-    maxCount: number;
+    minCount: number;
     additionalContext?: string;
 }

--- a/electron/agentic/create-solution-workflow/prompts/research-information.ts
+++ b/electron/agentic/create-solution-workflow/prompts/research-information.ts
@@ -6,7 +6,7 @@ import { toolUseContext } from "./tool-use.context";
 
 interface RequirementPreference {
   isEnabled: boolean;
-  maxCount: number;
+  minCount: number;
 }
 
 interface GatherInfoParams {

--- a/electron/agentic/create-solution-workflow/prompts/utils.ts
+++ b/electron/agentic/create-solution-workflow/prompts/utils.ts
@@ -2,7 +2,7 @@ import { REQUIREMENT_TYPE, REQUIREMENT_DISPLAY_NAME_PLURAL_MAP } from '../../../
 
 export interface RequirementPreference {
   isEnabled: boolean;
-  maxCount: number;
+  minCount: number;
 }
 
 export type RequirementPreferences = {

--- a/electron/agentic/create-solution-workflow/utils.ts
+++ b/electron/agentic/create-solution-workflow/utils.ts
@@ -10,7 +10,7 @@ export type BaseRequirementGenerationContext = {
     name: string;
     description: string;
   };
-  maxCount: number;
+  minCount: number;
   referenceInformation?: string;
 };
 
@@ -35,7 +35,7 @@ export const buildPromptForRequirement = (
   const { type, generationContext } = params;
   const {
     app: { name, description },
-    maxCount,
+    minCount,
     referenceInformation,
   } = generationContext;
 
@@ -44,28 +44,28 @@ export const buildPromptForRequirement = (
       return createBRDPrompt({
         name,
         description,
-        maxCount,
+        minCount,
         referenceInformation,
       });
     case "NFR":
       return createNFRPrompt({
         name,
         description,
-        maxCount,
+        minCount,
         referenceInformation,
       });
     case "UIR":
       return createUIRPrompt({
         name,
         description,
-        maxCount,
+        minCount,
         referenceInformation,
       });
     case "PRD":
       return createPRDPrompt({
         name,
         description,
-        maxCount,
+        minCount,
         brds: generationContext.brds,
         referenceInformation,
       });

--- a/electron/api/solution/create.ts
+++ b/electron/api/solution/create.ts
@@ -26,7 +26,7 @@ import { MCPSettingsManager } from '../../mcp/mcp-settings-manager';
 
 type RequirementTypeMeta = {
   key: keyof Pick<SolutionResponse, 'brd' | 'prd' | 'uir' | 'nfr'>;
-  generatePrompt: (params: { name: string; description: string; maxCount: number; brds?: any[] }) => string;
+  generatePrompt: (params: { name: string; description: string; minCount: number; brds?: any[] }) => string;
   preferencesKey: keyof Pick<CreateSolutionRequest, 'brdPreferences' | 'prdPreferences' | 'uirPreferences' | 'nfrPreferences'>;
 };
 
@@ -58,7 +58,7 @@ const generateRequirement = async ({ key, generatePrompt, preferencesKey, data, 
   const prompt = generatePrompt({
     name: data.name,
     description: data.description,
-    maxCount: preferences.maxCount,
+    minCount: preferences.minCount,
     brds
   });
   

--- a/electron/prompts/solution/create-brd.ts
+++ b/electron/prompts/solution/create-brd.ts
@@ -36,6 +36,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on the start and end of the response.
-Generate **at least ${minCount}** business requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Generate **${minCount}** business requirements. You may generate more if needed for clarity or completeness, but not fewer.
 Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/prompts/solution/create-brd.ts
+++ b/electron/prompts/solution/create-brd.ts
@@ -4,11 +4,11 @@ import { MARKDOWN_RULES } from '../context/markdown-rules';
 interface CreateBRDParams {
   name: string;
   description: string;
-  maxCount: number;
+  minCount: number;
   referenceInformation?: string;
 }
 
-export function createBRDPrompt({ name, description, maxCount, referenceInformation }: CreateBRDParams): string {
+export function createBRDPrompt({ name, description, minCount, referenceInformation }: CreateBRDParams): string {
   return `You are a requirements analyst tasked with extracting detailed Business Requirements from the provided app description.
 
 Below is the description of the app:
@@ -36,5 +36,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on the start and end of the response.
-Generate Business Requirements with a maximum count of ${maxCount}. Sort all requirements based on business impact (High to Medium to Low).`;
+Generate **at least ${minCount}** business requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/prompts/solution/create-nfr.ts
+++ b/electron/prompts/solution/create-nfr.ts
@@ -4,11 +4,11 @@ import { MARKDOWN_RULES } from '../context/markdown-rules';
 interface CreateNFRParams {
   name: string;
   description: string;
-  maxCount: number;
+  minCount: number;
   referenceInformation?: string;
 }
 
-export function createNFRPrompt({ name, description, maxCount, referenceInformation }: CreateNFRParams): string {
+export function createNFRPrompt({ name, description, minCount, referenceInformation }: CreateNFRParams): string {
   return `You are a requirements analyst tasked with extracting detailed Non-Functional Requirements from the provided app description. Below is the description of the app:
 
 App Name: ${name}
@@ -36,5 +36,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear, concise, and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate Non-Functional Requirements with a maximum count of ${maxCount}. Sort all requirements based on business impact (High to Medium to Low).`;
+Generate **at least ${minCount}** Non-Functional Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/prompts/solution/create-nfr.ts
+++ b/electron/prompts/solution/create-nfr.ts
@@ -36,6 +36,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear, concise, and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate **at least ${minCount}** Non-Functional Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Generate **${minCount}** Non-Functional Requirements. You may generate more if needed for clarity or completeness, but not fewer.
 Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/prompts/solution/create-prd.ts
+++ b/electron/prompts/solution/create-prd.ts
@@ -52,7 +52,7 @@ Special Instructions:
      The relationship is not strictly hierarchical.
 
 Please ensure the requirements are descriptive and also clear, concise. Output must be valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate **at least ${minCount}** Product Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Generate **${minCount}** Product Requirements. You may generate more if needed for clarity, completeness, or BRD coverage, but you MUST NOT generate fewer than ${minCount} requirements.
 Sort all requirements based on business impact (High to Medium to Low).`;
 }
 

--- a/electron/prompts/solution/create-prd.ts
+++ b/electron/prompts/solution/create-prd.ts
@@ -4,7 +4,7 @@ import { MARKDOWN_RULES } from '../context/markdown-rules';
 interface CreatePRDParams {
   name: string;
   description: string;
-  maxCount: number;
+  minCount: number;
   brds?: Array<{
     id: string;
     title: string;
@@ -13,7 +13,7 @@ interface CreatePRDParams {
   referenceInformation?:string;
 }
 
-export function createPRDPrompt({ name, description, maxCount, brds, referenceInformation }: CreatePRDParams): string {
+export function createPRDPrompt({ name, description, minCount, brds, referenceInformation }: CreatePRDParams): string {
   return `You are an award winning product manager tasked with extracting detailed Product Requirements from the provided information.
 ## App Description:
 
@@ -52,7 +52,8 @@ Special Instructions:
      The relationship is not strictly hierarchical.
 
 Please ensure the requirements are descriptive and also clear, concise. Output must be valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate Product Requirements with a maximum count of ${maxCount}. Sort all requirements based on business impact (High to Medium to Low).`;
+Generate **at least ${minCount}** Product Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Sort all requirements based on business impact (High to Medium to Low).`;
 }
 
 

--- a/electron/prompts/solution/create-uir.ts
+++ b/electron/prompts/solution/create-uir.ts
@@ -43,6 +43,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear, concise, and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate **at least ${minCount}** User Interface Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Generate **${minCount}** User Interface Requirements. You may generate more if needed for clarity or completeness, but not fewer.
 Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/prompts/solution/create-uir.ts
+++ b/electron/prompts/solution/create-uir.ts
@@ -4,14 +4,14 @@ import { UIR_CONTEXT } from "../context/uir";
 interface CreateUIRParams {
   name: string;
   description: string;
-  maxCount: number;
+  minCount: number;
   referenceInformation?: string;
 }
 
 export function createUIRPrompt({
   name,
   description,
-  maxCount,
+  minCount,
   referenceInformation,
 }: CreateUIRParams): string {
   return `You are a requirements analyst tasked with extracting User Interface Requirements from the provided app description. Below is the description of the app:
@@ -43,5 +43,6 @@ Special Instructions:
   ${MARKDOWN_RULES}
 
 Please ensure the requirements are clear, concise, and comprehensive. Output only valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.
-Generate User Interface Requirements with a maximum count of ${maxCount}. Sort all requirements based on business impact (High to Medium to Low).`;
+Generate **at least ${minCount}** User Interface Requirements. You may generate more if needed for clarity or completeness, but not fewer.
+Sort all requirements based on business impact (High to Medium to Low).`;
 }

--- a/electron/schema/solution/create.schema.ts
+++ b/electron/schema/solution/create.schema.ts
@@ -2,7 +2,7 @@ import { McpSettingsSchema } from '../../mcp/schema';
 import { z } from 'zod';
 
 export const generationRangeSchema = z.object({
-  maxCount: z.number(),
+  minCount: z.number(),
   isEnabled: z.boolean()
 });
 

--- a/ui/src/app/model/interfaces/projects.interface.ts
+++ b/ui/src/app/model/interfaces/projects.interface.ts
@@ -6,13 +6,13 @@ export interface IProject {
 }
 
 export interface IGenerationRange {
-  maxCount: number;
+  minCount: number;
   isEnabled: boolean;
 }
 
 export interface IRequirementConfig {
   enabled?: boolean;
-  maxCount?: number;
+  minCount?: number;
   count: number;
 }
 

--- a/ui/src/app/pages/create-solution/create-solution.component.html
+++ b/ui/src/app/pages/create-solution/create-solution.component.html
@@ -105,12 +105,12 @@
                         " (toggleChange)="onRequirementToggle('BRD', $event)" isPlainToggle="true"></app-toggle>
                       </div>
                       <p class="text-xs leading-6 text-secondary-600 ml-4">
-                        Enable to set maximum number of Business Requirements
+                        Enable to set minimum number of Business Requirements
                       </p>
                     </div>
                     <div class="mt-4" *ngIf="solutionForm.get('BRD')?.get('enabled')?.value">
                       <div class="border rounded-lg p-4 max-w-[28rem]" formGroupName="BRD">
-                        <app-slider formControlName="maxCount"></app-slider>
+                        <app-slider formControlName="minCount"></app-slider>
                       </div>
                     </div>
                   </div>
@@ -130,12 +130,12 @@
                         " (toggleChange)="onRequirementToggle('PRD', $event)" isPlainToggle="true"></app-toggle>
                       </div>
                       <p class="text-xs leading-6 text-secondary-600 ml-4">
-                        Enable to set maximum number of Product Requirements
+                        Enable to set minimum number of Product Requirements
                       </p>
                     </div>
                     <div class="mt-4" *ngIf="solutionForm.get('PRD')?.get('enabled')?.value">
                       <div class="border rounded-lg p-4 max-w-[28rem]" formGroupName="PRD">
-                        <app-slider formControlName="maxCount"></app-slider>
+                        <app-slider formControlName="minCount"></app-slider>
                       </div>
                     </div>
                   </div>
@@ -155,12 +155,12 @@
                         " (toggleChange)="onRequirementToggle('UIR', $event)" isPlainToggle="true"></app-toggle>
                       </div>
                       <p class="text-xs leading-6 text-secondary-600 ml-4">
-                        Enable to set maximum number of UI Requirements
+                        Enable to set minimum number of UI Requirements
                       </p>
                     </div>
                     <div class="mt-4" *ngIf="solutionForm.get('UIR')?.get('enabled')?.value">
                       <div class="border rounded-lg p-4 max-w-[28rem]" formGroupName="UIR">
-                        <app-slider formControlName="maxCount"></app-slider>
+                        <app-slider formControlName="minCount"></app-slider>
                       </div>
                     </div>
                   </div>
@@ -180,13 +180,13 @@
                         " (toggleChange)="onRequirementToggle('NFR', $event)" isPlainToggle="true"></app-toggle>
                       </div>
                       <p class="text-xs leading-6 text-secondary-600 ml-4">
-                        Enable to set maximum number of Non-Functional
+                        Enable to set minimum number of Non-Functional
                         Requirements
                       </p>
                     </div>
                     <div class="mt-4" *ngIf="solutionForm.get('NFR')?.get('enabled')?.value">
                       <div class="border rounded-lg p-4 max-w-[28rem]" formGroupName="NFR">
-                        <app-slider formControlName="maxCount"></app-slider>
+                        <app-slider formControlName="minCount"></app-slider>
                       </div>
                     </div>
                   </div>

--- a/ui/src/app/pages/create-solution/create-solution.component.ts
+++ b/ui/src/app/pages/create-solution/create-solution.component.ts
@@ -84,10 +84,10 @@ export class CreateSolutionComponent implements OnInit {
     return !this.solutionForm.get('cleanSolution')?.value;
   }
 
-  private initRequirementGroup(enabled: boolean = true, maxCount: number = REQUIREMENT_COUNT.DEFAULT) {
+  private initRequirementGroup(enabled: boolean = true, minCount: number = REQUIREMENT_COUNT.DEFAULT) {
     return {
       enabled: new FormControl(enabled),
-      maxCount: new FormControl(maxCount, {
+      minCount: new FormControl(minCount, {
         validators: [
           Validators.required,
           Validators.min(0),
@@ -130,15 +130,15 @@ export class CreateSolutionComponent implements OnInit {
     const requirementGroup = this.solutionForm.get(type);
     if (!requirementGroup) return;
     
-    // Always set a valid maxCount value whether enabled or disabled
-    const maxCount = enabled ? REQUIREMENT_COUNT.DEFAULT : 0;
+    // Always set a valid minCount value whether enabled or disabled
+    const minCount = enabled ? REQUIREMENT_COUNT.DEFAULT : 0;
     requirementGroup.patchValue({
       enabled,
-      maxCount
+      minCount
     });
     
     // Ensure the control is marked as touched to trigger validation
-    requirementGroup.get('maxCount')?.markAsTouched();
+    requirementGroup.get('minCount')?.markAsTouched();
     requirementGroup.get('enabled')?.markAsTouched();
     requirementGroup.updateValueAndValidity();
   }

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -171,19 +171,19 @@ export class ProjectsState {
         description: metadata.description,
         cleanSolution: metadata.cleanSolution,
         brdPreferences: {
-          maxCount: metadata.BRD.maxCount,
+          minCount: metadata.BRD.minCount,
           isEnabled: metadata.BRD.enabled,
         },
         prdPreferences: {
-          maxCount: metadata.PRD.maxCount,
+          minCount: metadata.PRD.minCount,
           isEnabled: metadata.PRD.enabled,
         },
         uirPreferences: {
-          maxCount: metadata.UIR.maxCount,
+          minCount: metadata.UIR.minCount,
           isEnabled: metadata.UIR.enabled,
         },
         nfrPreferences: {
-          maxCount: metadata.NFR.maxCount,
+          minCount: metadata.NFR.minCount,
           isEnabled: metadata.NFR.enabled,
         },
         mcpSettings: metadata.mcpSettings


### PR DESCRIPTION
### Description

This PR updates the requirement generation logic by replacing the previously used **maximum requirement count** with a **minimum requirement count**. This change ensures that a minimum number of requirements must be generated, allowing for more flexible and accurate control over requirement thresholds.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)  
-   [x] ✨ New feature (non-breaking change which adds functionality)  
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] 📚 Documentation update  

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)  
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specifai/blob/main/CONTRIBUTING.md)  

