### PR TITLE
fix: pass tools to summary call in react agent

### DIFF
--- a/electron/agentic/react-agent/index.ts
+++ b/electron/agentic/react-agent/index.ts
@@ -35,7 +35,7 @@ export const buildReactAgent = <
   const builder = new StateGraph(
     createReactAgentAnnotation<TStructuredResponse>()
   )
-    .addNode("summarize", buildSummarizeNode(model, summaryConfig))
+    .addNode("summarize", buildSummarizeNode(model, tools, summaryConfig))
     .addNode("llm", buildLLMNode(model, tools))
     .addNode("tools", new ToolNode(tools))
     .addEdge(START, "summarize")

--- a/electron/agentic/react-agent/nodes.ts
+++ b/electron/agentic/react-agent/nodes.ts
@@ -27,9 +27,10 @@ const DEFAULT_SUMMARY_CONFIG: MessageSummaryConfig = {
 // Node for handling message summarization
 export const buildSummarizeNode = (
   modelProvider: LangChainModelProvider,
+  tools: Array<ITool>,
   config: MessageSummaryConfig = DEFAULT_SUMMARY_CONFIG
 ) => {
-  const model = modelProvider.getModel();
+  const modelWithTools = modelProvider.getModel().bindTools!(tools);
 
   return async (
     state: (typeof MessagesAnnotation)["State"] & {
@@ -70,7 +71,7 @@ export const buildSummarizeNode = (
       ];
 
       // Generate new summary
-      const response = await model.invoke(allMessages);
+      const response = await modelWithTools.invoke(allMessages);
       const newSummary =
         typeof response.content === "string"
           ? response.content


### PR DESCRIPTION
### Description

pass tools to summary call in react agent

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

### Screenshots

<!-- For UI changes, add screenshots here -->

### Additional Notes

<!-- Add any additional notes for reviewers -->
