### PR TITLE
feat: add sendMessagesInTelemetry option to workflow configurations

### DIFF
--- a/.changeset/rude-dolls-pump.md
+++ b/.changeset/rude-dolls-pump.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+Introduced a new configuration option `sendMessagesInTelemetry` to workflow settings. When enabled, this flag allows telemetry data to include sent messages.

--- a/electron/agentic/suggestion-workflow/nodes.ts
+++ b/electron/agentic/suggestion-workflow/nodes.ts
@@ -145,11 +145,7 @@ export const buildGenerateSuggestionsNode = (
         name: "llm",
         model: modelProvider.getModel().id,
         environment: process.env.APP_ENVIRONMENT,
-        input: sendMessagesInTelemetry
-          ? state.messages.length > 0
-            ? state.messages
-            : [new HumanMessage(prompt)]
-          : undefined,
+        input: sendMessagesInTelemetry ? prompt : undefined,
       });
 
       // LLM Call

--- a/electron/agentic/suggestion-workflow/types.ts
+++ b/electron/agentic/suggestion-workflow/types.ts
@@ -6,5 +6,6 @@ export interface SuggestionWorkflowRunnableConfig
   configurable?: {
     trace?: LangfuseObservationClient;
     thread_id?: string;
+    sendMessagesInTelemetry?: boolean;
   };
 }

--- a/electron/agentic/task-workflow/nodes.ts
+++ b/electron/agentic/task-workflow/nodes.ts
@@ -130,11 +130,7 @@ export const buildGenerateTasksNode = (
         name: "llm",
         model: modelProvider.getModel().id,
         environment: process.env.APP_ENVIRONMENT,
-        input: sendMessagesInTelemetry
-          ? state.messages.length > 0
-            ? state.messages
-            : [new HumanMessage(prompt)]
-          : undefined,
+        input: sendMessagesInTelemetry ? prompt : undefined,
       });
 
       // LLM Call

--- a/electron/agentic/task-workflow/nodes.ts
+++ b/electron/agentic/task-workflow/nodes.ts
@@ -26,7 +26,8 @@ export const buildResearchNode = ({
     state: ITaskWorkflowStateAnnotation["State"],
     runnableConfig: TaskWorkflowRunnableConfig
   ) => {
-    const trace = runnableConfig.configurable?.trace;
+    const { trace, sendMessagesInTelemetry = false } =
+      runnableConfig.configurable ?? {};
     const span = trace?.span({
       name: "research",
     });
@@ -86,6 +87,7 @@ export const buildResearchNode = ({
         configurable: {
           trace: span,
           thread_id: runnableConfig.configurable?.thread_id,
+          sendMessagesInTelemetry: sendMessagesInTelemetry,
         },
       }
     );
@@ -108,7 +110,8 @@ export const buildGenerateTasksNode = (
     state: ITaskWorkflowStateAnnotation["State"],
     runnableConfig: TaskWorkflowRunnableConfig
   ) => {
-    const trace = runnableConfig.configurable?.trace;
+    const { trace, sendMessagesInTelemetry = false } =
+      runnableConfig.configurable ?? {};
     const span = trace?.span({
       name: "generate-tasks",
     });
@@ -123,9 +126,29 @@ export const buildGenerateTasksNode = (
         referenceInformation: state.referenceInformation,
       });
 
+      const generation = span?.generation({
+        name: "llm",
+        model: modelProvider.getModel().id,
+        environment: process.env.APP_ENVIRONMENT,
+        input: sendMessagesInTelemetry
+          ? state.messages.length > 0
+            ? state.messages
+            : [new HumanMessage(prompt)]
+          : undefined,
+      });
+
       // LLM Call
       const model = modelProvider.getChatModel();
       const response = await model.invoke(prompt);
+
+      generation?.end({
+        usage: {
+          input: response.usage_metadata?.input_tokens,
+          output: response.usage_metadata?.output_tokens,
+          total: response.usage_metadata?.total_tokens,
+        },
+        output: sendMessagesInTelemetry ? response : undefined,
+      });
 
       let parsedTasks;
       try {

--- a/electron/agentic/task-workflow/types.ts
+++ b/electron/agentic/task-workflow/types.ts
@@ -5,5 +5,6 @@ export interface TaskWorkflowRunnableConfig extends LangGraphRunnableConfig {
   configurable?: {
     trace?: LangfuseObservationClient;
     thread_id?: string;
+    sendMessagesInTelemetry?: boolean;
   };
 }

--- a/electron/agentic/user-story-workflow/types.ts
+++ b/electron/agentic/user-story-workflow/types.ts
@@ -6,5 +6,6 @@ export interface UserStoryWorkflowRunnableConfig
   configurable?: {
     trace?: LangfuseObservationClient;
     thread_id?: string;
+    sendMessagesInTelemetry?: boolean;
   };
 }

--- a/electron/api/core/get-suggestions.ts
+++ b/electron/api/core/get-suggestions.ts
@@ -9,6 +9,7 @@ import { buildLangchainModelProvider } from '../../services/llm/llm-langchain';
 import { ObservabilityManager } from '../../services/observability/observability.manager';
 import { getMcpToolsForActiveProvider } from '../../mcp';
 import { MCPHub } from '../../mcp/mcp-hub';
+import { isDevEnv } from '../../utils/env';
 
 export async function getSuggestions(_: IpcMainInvokeEvent, data: unknown): Promise<string[]> {
   try {
@@ -57,12 +58,13 @@ export async function getSuggestions(_: IpcMainInvokeEvent, data: unknown): Prom
     };
     
     const config = {
-      "configurable": {
-        "thread_id": `${randomUUID()}_get_suggestions`,
-        "trace": trace
-      }
+      configurable: {
+        thread_id: `${randomUUID()}_get_suggestions`,
+        trace: trace,
+        sendMessagesInTelemetry: isDevEnv(),
+      },
     };
-    
+
     const stream = suggestionWorkflow.streamEvents(initialState, {
       version: "v2",
       streamMode: "messages",

--- a/electron/api/feature/story/create.ts
+++ b/electron/api/feature/story/create.ts
@@ -9,6 +9,7 @@ import { buildLangchainModelProvider } from '../../../services/llm/llm-langchain
 import { ObservabilityManager } from '../../../services/observability/observability.manager';
 import { getMcpToolsForActiveProvider } from '../../../mcp';
 import { MCPHub } from '../../../mcp/mcp-hub';
+import { isDevEnv } from '../../../utils/env';
 
 export async function createStories(_: IpcMainInvokeEvent, data: unknown): Promise<CreateStoryResponse> {
   try {
@@ -63,10 +64,11 @@ export async function createStories(_: IpcMainInvokeEvent, data: unknown): Promi
     };
     
     const config = {
-      "configurable": {
-        "thread_id": `${randomUUID()}_create_stories`,
-        "trace": trace
-      }
+      configurable: {
+        thread_id: `${randomUUID()}_create_stories`,
+        trace: trace,
+        sendMessagesInTelemetry: isDevEnv(),
+      },
     };
     
     const stream = userStoryWorkflow.streamEvents(initialState, {

--- a/electron/api/feature/story/update.ts
+++ b/electron/api/feature/story/update.ts
@@ -8,16 +8,24 @@ import { updateStoryPrompt } from '../../../prompts/feature/story/update';
 import { repairJSON } from '../../../utils/custom-json-parser';
 import { traceBuilder } from '../../../utils/trace-builder';
 import { COMPONENT, OPERATIONS } from '../../../helper/constants';
+import { ObservabilityManager } from '../../../services/observability/observability.manager';
+import { HumanMessage } from "@langchain/core/messages";
+import { isDevEnv } from '../../../utils/env';
 
 export async function updateStory(event: IpcMainInvokeEvent, data: unknown): Promise<UpdateStoryResponse> {
   try {
     const llmConfig = store.get<LLMConfigModel>('llmConfig');
+    const o11y = ObservabilityManager.getInstance();
+    const trace = o11y.createTrace('update-story');
+
     if (!llmConfig) {
       throw new Error('LLM configuration not found');
     }
 
     console.log('[update-story] Using LLM config:', llmConfig);
+    const validationSpan = trace.span({name: "input-validation"});
     const validatedData = updateStorySchema.parse(data);
+    validationSpan.end();
 
     const prompt = updateStoryPrompt({
       name: validatedData.name,
@@ -36,10 +44,29 @@ export async function updateStory(event: IpcMainInvokeEvent, data: unknown): Pro
     );
 
     const traceName = traceBuilder(COMPONENT.STORY, OPERATIONS.UPDATE);
-    const response = await handler.invoke(messages, null, traceName);
-    const cleanFeatures = repairJSON(response.trim());
+    const llmSpan = trace.span({
+      name: "update-user-story",
+    });
     
+    const generation = llmSpan.generation({
+      name: "llm",
+      model: llmConfig.activeProvider,
+      environment: process.env.APP_ENVIRONMENT,
+      input: isDevEnv() ? [new HumanMessage(prompt)] : undefined,
+    });
+
+    const response = await handler.invoke(messages, null, traceName);
     console.log('[update-story] LLM Response:', response);
+
+    generation.end({
+      output: isDevEnv() ? response : undefined,
+    });
+
+    llmSpan.end({
+      statusMessage: "Successfully updated user story"
+    });
+
+    const cleanFeatures = repairJSON(response.trim());
 
     try {
       const parsedResponse = JSON.parse(cleanFeatures.trim());
@@ -53,6 +80,10 @@ export async function updateStory(event: IpcMainInvokeEvent, data: unknown): Pro
       };
     } catch (error) {
       console.error('Error processing LLM response:', error);
+      llmSpan.end({
+        level: "ERROR",
+        statusMessage: `Error processing LLM response: ${error}`
+      });
       throw error;
     }
   } catch (error) {

--- a/electron/api/feature/task/create.ts
+++ b/electron/api/feature/task/create.ts
@@ -9,6 +9,7 @@ import { buildLangchainModelProvider } from '../../../services/llm/llm-langchain
 import { ObservabilityManager } from '../../../services/observability/observability.manager';
 import { getMcpToolsForActiveProvider } from '../../../mcp';
 import { MCPHub } from '../../../mcp/mcp-hub';
+import { isDevEnv } from '../../../utils/env';
 
 export async function createTask(event: IpcMainInvokeEvent, data: any): Promise<CreateTaskResponse> {
   try {
@@ -53,10 +54,11 @@ export async function createTask(event: IpcMainInvokeEvent, data: any): Promise<
     };
     
     const config = {
-      "configurable": {
-        "thread_id": `${randomUUID()}_create_tasks`,
-        "trace": trace
-      }
+      configurable: {
+        thread_id: `${randomUUID()}_create_tasks`,
+        trace: trace,
+        sendMessagesInTelemetry: isDevEnv(),
+      },
     };
     
     const stream = taskWorkflow.streamEvents(initialState, {

--- a/electron/api/requirement/business-process/add.ts
+++ b/electron/api/requirement/business-process/add.ts
@@ -8,16 +8,24 @@ import { addBusinessProcessPrompt } from '../../../prompts/requirement/business-
 import { repairJSON } from '../../../utils/custom-json-parser';
 import { OPERATIONS, COMPONENT } from '../../../helper/constants';
 import { traceBuilder } from '../../../utils/trace-builder';
+import { ObservabilityManager } from '../../../services/observability/observability.manager';
+import { HumanMessage } from "@langchain/core/messages";
+import { isDevEnv } from '../../../utils/env';
 
 export async function addBusinessProcess(event: IpcMainInvokeEvent, data: any): Promise<AddBusinessProcessResponse> {
   try {
     const llmConfig = store.get<LLMConfigModel>('llmConfig');
+    const o11y = ObservabilityManager.getInstance();
+    const trace = o11y.createTrace('add-business-process');
+
     if (!llmConfig) {
       throw new Error('LLM configuration not found');
     }
 
     console.log('[add-business-process] Using LLM config:', llmConfig);
+    const validationSpan = trace.span({name: "input-validation"});
     const validatedData = addBusinessProcessSchema.parse(data);
+    validationSpan.end();
 
     const {
       name,
@@ -55,17 +63,45 @@ export async function addBusinessProcess(event: IpcMainInvokeEvent, data: any): 
     );
 
     const traceName = traceBuilder(COMPONENT.BP, OPERATIONS.ADD);
+    const llmSpan = trace.span({
+      name: "add-business-process",
+    });
+    
+    const generation = llmSpan.generation({
+      name: "llm",
+      model: llmConfig.activeProvider,
+      environment: process.env.APP_ENVIRONMENT,
+      input: isDevEnv() ? [new HumanMessage(prompt)] : undefined,
+    });
+
     const response = await handler.invoke(messages, null, traceName);
     console.log('[add-business-process] LLM Response:', response);
 
-    // Parse LLM response
-    const cleanedResponse = repairJSON(response);
-    const llmResponse = JSON.parse(cleanedResponse);
+    generation.end({
+      output: isDevEnv() ? response : undefined,
+    });
 
-    return {
-      ...validatedData,
-      LLMreqt: llmResponse.LLMreqt
-    };
+    llmSpan.end({
+      statusMessage: "Successfully generated business process"
+    });
+
+    // Parse LLM response
+    try {
+      const cleanedResponse = repairJSON(response);
+      const llmResponse = JSON.parse(cleanedResponse);
+
+      return {
+        ...validatedData,
+        LLMreqt: llmResponse.LLMreqt
+      };
+    } catch (error) {
+      console.error('Error parsing LLM response:', error);
+      llmSpan.end({
+        level: "ERROR",
+        statusMessage: `Error parsing LLM response: ${error}`
+      });
+      throw error;
+    }
   } catch (error) {
     console.error('Error in addBusinessProcess:', error);
     throw error;

--- a/electron/api/requirement/business-process/update.ts
+++ b/electron/api/requirement/business-process/update.ts
@@ -8,16 +8,24 @@ import { updateBusinessProcessPrompt } from '../../../prompts/requirement/busine
 import { repairJSON } from '../../../utils/custom-json-parser';
 import { COMPONENT, OPERATIONS } from '../../../helper/constants';
 import { traceBuilder } from '../../../utils/trace-builder';
+import { ObservabilityManager } from '../../../services/observability/observability.manager';
+import { HumanMessage } from "@langchain/core/messages";
+import { isDevEnv } from '../../../utils/env';
 
 export async function updateBusinessProcess(event: IpcMainInvokeEvent, data: any): Promise<UpdateBusinessProcessResponse> {
   try {
     const llmConfig = store.get<LLMConfigModel>('llmConfig');
+    const o11y = ObservabilityManager.getInstance();
+    const trace = o11y.createTrace('update-business-process');
+
     if (!llmConfig) {
       throw new Error('LLM configuration not found');
     }
 
     console.log('[update-business-process] Using LLM config:', llmConfig);
+    const validationSpan = trace.span({name: "input-validation"});
     const validatedData = updateBusinessProcessSchema.parse(data);
+    validationSpan.end();
 
     const {
       name,
@@ -57,17 +65,45 @@ export async function updateBusinessProcess(event: IpcMainInvokeEvent, data: any
     );
 
     const traceName = traceBuilder(COMPONENT.BP, OPERATIONS.UPDATE);
+    const llmSpan = trace.span({
+      name: "update-business-process",
+    });
+    
+    const generation = llmSpan.generation({
+      name: "llm",
+      model: llmConfig.activeProvider,
+      environment: process.env.APP_ENVIRONMENT,
+      input: isDevEnv() ? [new HumanMessage(prompt)] : undefined,
+    });
+
     const response = await handler.invoke(messages, null, traceName);
     console.log('[update-business-process] LLM Response:', response);
 
-    // Parse LLM response
-    const cleanedResponse = repairJSON(response);
-    const llmResponse = JSON.parse(cleanedResponse);
+    generation.end({
+      output: isDevEnv() ? response : undefined,
+    });
 
-    return {
-      ...validatedData,
-      updated: llmResponse.updated
-    };
+    llmSpan.end({
+      statusMessage: "Successfully updated business process"
+    });
+
+    // Parse LLM response
+    try {
+      const cleanedResponse = repairJSON(response);
+      const llmResponse = JSON.parse(cleanedResponse);
+
+      return {
+        ...validatedData,
+        updated: llmResponse.updated
+      };
+    } catch (error) {
+      console.error('Error parsing LLM response:', error);
+      llmSpan.end({
+        level: "ERROR",
+        statusMessage: `Error parsing LLM response: ${error}`
+      });
+      throw error;
+    }
   } catch (error) {
     console.error('Error in updateBusinessProcess:', error);
     throw error;


### PR DESCRIPTION

### Description

This PR introduces a new configuration option `sendMessagesInTelemetry` to the workflow settings. When enabled, this flag allows telemetry data.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

