### PR TITLE
fix(ui): remove left padding in fullscreen mode to align header with screen edge

### DIFF
--- a/electron/app.ts
+++ b/electron/app.ts
@@ -101,6 +101,18 @@ function onAppReload(indexPath: string) {
 }
 
 function setupWindowHandlers(window: BrowserWindow, indexPath: string) {
+  window.on("enter-full-screen", () => {
+    window?.webContents.send("fullscreen-change", true);
+  });
+
+  window.on("leave-full-screen", () => {
+    window?.webContents.send("fullscreen-change", false);
+  });
+
+  ipcMain.handle("window:get-fullscreen", () => {
+    return window?.isFullScreen();
+  });
+
   window.webContents.setWindowOpenHandler(() => {
     return { action: "deny" };
   });

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -87,6 +87,16 @@ const mcpListeners = {
   setProjectId: () => ipcRenderer.invoke("mcp:setProjectId"),
 }
 
+const windowListeners = {
+  onFullscreenChange: (callback: (isFullscreen: boolean) => void) => {
+    ipcRenderer.on("fullscreen-change", (_event, isFullscreen) => callback(isFullscreen));
+  },
+  removeFullscreenListener: () => {
+    ipcRenderer.removeAllListeners("fullscreen-change");
+  },
+  getFullscreenState: () => ipcRenderer.invoke("window:get-fullscreen")
+};
+
 const electronAPI = {
   ...electronListeners,
   ...coreListeners,
@@ -95,7 +105,8 @@ const electronAPI = {
   ...visualizationListeners,
   ...featureListeners,
   ...appAutoUpdaterListeners,
-  ...mcpListeners
+  ...mcpListeners,
+  ...windowListeners
 };
 
 contextBridge.exposeInMainWorld("electronAPI", electronAPI);

--- a/ui/src/app/components/layout/header/header.component.html
+++ b/ui/src/app/components/layout/header/header.component.html
@@ -3,7 +3,7 @@
     class="bg-white border-b [app-region:drag] select-none h-[39px] w-full"
   >
     <div class="flex items-center justify-between pl-4">
-      <div [ngClass]="{ 'pl-16': isMacOS }">
+      <div [ngClass]="{ 'pl-16': isMacOS && !isFullscreen }">
         <app-breadcrumbs />
       </div>
       <div class="flex items-center gap-x-3">

--- a/ui/src/app/components/layout/header/header.component.ts
+++ b/ui/src/app/components/layout/header/header.component.ts
@@ -1,6 +1,7 @@
 import { Component, NgZone, OnDestroy, OnInit, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { StartupService } from '../../../services/auth/startup.service';
+import { ElectronService } from '../../../electron-bridge/electron.service';
 import { environment } from '../../../../environments/environment';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import { BreadcrumbsComponent } from '../../core/breadcrumbs/breadcrumbs.component';
@@ -32,15 +33,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
   startupService = inject(StartupService);
   router = inject(Router);
   private ngZone = inject(NgZone);
+  private electronService = inject(ElectronService);
 
   ngOnInit() {
-    window.electronAPI.onFullscreenChange((isFullscreen: boolean) => {
+    this.electronService.onFullscreenChange((isFullscreen: boolean) => {
       this.ngZone.run(() => {
         this.isFullscreen = isFullscreen;
       });
     });
 
-    window.electronAPI.getFullscreenState().then((isFullscreen: boolean) => {
+    this.electronService.getFullscreenState().then((isFullscreen: boolean) => {
       this.ngZone.run(() => {
         this.isFullscreen = isFullscreen;
       });
@@ -48,7 +50,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    window.electronAPI.removeFullscreenListener();
+    this.electronService.removeFullscreenListener();
   }
 
   navigateToSettings() {

--- a/ui/src/app/components/layout/header/header.component.ts
+++ b/ui/src/app/components/layout/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, NgZone, OnDestroy, OnInit, inject } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { StartupService } from '../../../services/auth/startup.service';
 import { environment } from '../../../../environments/environment';
@@ -24,12 +24,32 @@ import { heroCog8Tooth } from '@ng-icons/heroicons/outline';
   ],
   viewProviders: [provideIcons({ heroCog8Tooth })],
 })
-export class HeaderComponent {
+export class HeaderComponent implements OnInit, OnDestroy {
   protected themeConfiguration = environment.ThemeConfiguration;
   protected isMacOS = navigator.platform.toLowerCase().includes('mac');
+  protected isFullscreen = false;
 
   startupService = inject(StartupService);
   router = inject(Router);
+  private ngZone = inject(NgZone);
+
+  ngOnInit() {
+    window.electronAPI.onFullscreenChange((isFullscreen: boolean) => {
+      this.ngZone.run(() => {
+        this.isFullscreen = isFullscreen;
+      });
+    });
+
+    window.electronAPI.getFullscreenState().then((isFullscreen: boolean) => {
+      this.ngZone.run(() => {
+        this.isFullscreen = isFullscreen;
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    window.electronAPI.removeFullscreenListener();
+  }
 
   navigateToSettings() {
     this.router.navigate(['/settings']);

--- a/ui/src/app/electron-bridge/electron.interface.ts
+++ b/ui/src/app/electron-bridge/electron.interface.ts
@@ -96,6 +96,9 @@ export interface ElectronAPI {
   createTask(request: ITaskRequest): Promise<ITasksResponse>;
   addTask(request: IAddTaskRequest): Promise<ITasksResponse>;
   updateTask(request: IAddTaskRequest): Promise<ITasksResponse>;
+  onFullscreenChange: (callback: (isFullscreen: boolean) => void) => void;
+  removeFullscreenListener: () => void;
+  getFullscreenState: () => Promise<boolean>;
 }
 
 declare global {

--- a/ui/src/app/electron-bridge/electron.service.ts
+++ b/ui/src/app/electron-bridge/electron.service.ts
@@ -579,4 +579,23 @@ export class ElectronService {
     }
     return this.electronAPI.invoke('open-external-url', url);
   }
+
+  onFullscreenChange(callback: (isFullscreen: boolean) => void): void {
+    if (this.electronAPI) {
+      this.electronAPI.onFullscreenChange(callback);
+    }
+  }
+
+  removeFullscreenListener(): void {
+    if (this.electronAPI) {
+      this.electronAPI.removeFullscreenListener();
+    }
+  }
+
+  async getFullscreenState(): Promise<boolean> {
+    if (this.electronAPI) {
+      return this.electronAPI.getFullscreenState();
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
### Description

This PR fixes a UI issue where the header retained unnecessary left padding when the Electron app was in fullscreen mode. This padding caused the breadcrumbs and traffic lights to be misaligned from the screen edge. 
### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)  
-   [ ] ✨ New feature (non-breaking change which adds functionality)  
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] 📚 Documentation update  

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)  
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)  

### Screenshots

<!-- For UI changes, add screenshots here -->

https://github.com/user-attachments/assets/86dc41d0-bdaf-4536-94b3-3675b53dc789