### PR TITLE
Fix: Regenerate Business Process Functionality

### DIFF
--- a/electron/file-system.utility.ts
+++ b/electron/file-system.utility.ts
@@ -32,6 +32,11 @@ interface FileChunkParams extends FileParams {
   filterString: string;
 }
 
+interface ISelectedRequirement {
+  requirement: string;
+  fileName: string;
+}
+
 export const utilityFunctionMap = {
   createDirectoryWithMetadata: createDirectoryWithMetadata,
   readDirectoryMetadata: readDirectoryMetadata,
@@ -241,6 +246,8 @@ type FileChunk = {
   message?: string;
   linkedBRDIds?: Array<string>;
   epicTicketId?: string | null;
+  selectedBRDs?: Array<ISelectedRequirement>;
+  selectedPRDs?: Array<ISelectedRequirement>;
 };
 
 function readFileChunk(
@@ -283,6 +290,12 @@ function readFileChunk(
           // populated linked brd ids in prd base files
           if (parsed.linkedBRDIds && !dataExtracted.linkedBRDIds) {
             dataExtracted.linkedBRDIds = parsed.linkedBRDIds;
+          }
+          if (parsed.selectedBRDs && !dataExtracted.selectedBRDs) {
+            dataExtracted.selectedBRDs = parsed.selectedBRDs;
+          }
+          if (parsed.selectedPRDs && !dataExtracted.selectedPRDs) {
+            dataExtracted.selectedPRDs = parsed.selectedPRDs;
           }
           if (dataExtracted.requirement && dataExtracted.title) {
             fs.close(fd, () => {});

--- a/ui/src/app/components/document-listing/document-listing.component.ts
+++ b/ui/src/app/components/document-listing/document-listing.component.ts
@@ -6,7 +6,7 @@ import { BulkReadFiles, ExportRequirementData } from '../../store/projects/proje
 import { getDescriptionFromInput } from '../../utils/common.utils';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { Router } from '@angular/router';
-import { IList } from '../../model/interfaces/IList';
+import { IList, SelectedDocument } from '../../model/interfaces/IList';
 import { RequirementTypeEnum } from '../../model/enum/requirement-type.enum';
 import { AsyncPipe, NgClass, NgForOf, NgIf } from '@angular/common';
 import { BadgeComponent } from '../core/badge/badge.component';
@@ -239,7 +239,17 @@ export class DocumentListingComponent implements OnInit, OnDestroy, AfterViewIni
         id: item.id,
         folderName: item.folderName,
         fileName: item.fileName,
-        req: item.content,
+        req: {
+          ...item.content,
+          selectedBRDs:
+            item?.content?.selectedBRDs?.map(
+              (brd: SelectedDocument) => brd?.requirement || brd,
+            ) || [],
+          selectedPRDs:
+            item?.content?.selectedPRDs?.map(
+              (prd: SelectedDocument) => prd?.requirement || prd,
+            ) || [],
+        },
         selectedFolder: {
           title: item.folderName,
           id: this.appInfo.id,

--- a/ui/src/app/model/interfaces/IList.ts
+++ b/ui/src/app/model/interfaces/IList.ts
@@ -4,12 +4,19 @@ export interface IList{
   content: IProjectDocument
 }
 
+export interface SelectedDocument {
+  requirement: string;
+  fileName: string;
+}
+
 export interface IProjectDocument {
   requirement?: string;
   title?: string;
   epicTicketId?: string;
   features?: IFeature[];
   linkedBRDIds?: string[];
+  selectedBRDs?: SelectedDocument[];
+  selectedPRDs?: SelectedDocument[];
   chatHistory?: [];
 }
 

--- a/ui/src/app/store/projects/projects.state.ts
+++ b/ui/src/app/store/projects/projects.state.ts
@@ -499,13 +499,7 @@ export class ProjectsState {
     );
 
     const nonNullFileContents = fileContents.filter(
-      (
-        file,
-      ): file is {
-        folderName: string;
-        fileName: string;
-        content: { requirement: string; title: string; epicTicketId: string };
-      } => file !== null,
+      (file): file is IList => file !== null,
     );
 
     patchState({


### PR DESCRIPTION
### Description

This PR addresses a bug where the "Regenerate BP" functionality failed due to incomplete metadata being read from BP files. It ensures proper extraction and mapping of `selectedBRDs`, `selectedPRDs`, and other related fields, enabling the Business Process Flow to function as intended.

## Problem
- BulkReadFiles was only reading `title` and `requirement` fields from BP files
- `selectedBRDs` and `selectedPRDs` arrays were missing from the extracted data
- Business Process Flow component couldn't access the complete requirement information
- Flow chart generation was failing due to missing selected requirements data

## Solution
Enhanced the file reading system to extract complete BP file metadata:

### Changes Made

#### 1. File System Utility (`electron/file-system.utility.ts`)
- Extended `FileChunk` type to include:
  - `selectedBRDs?: Array<ISelectedRequirement>`
  - `selectedPRDs?: Array<ISelectedRequirement>`

#### 4. Document Listing Component (`ui/src/app/components/document-listing/document-listing.component.ts`)
- Fixed `navigateToBPFlow` method with proper data mapping
- Added null checks and fallback logic
- Maps `selectedBRDs` and `selectedPRDs` to extract requirement strings as expected by BP Flow component

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

### Screenshots

![Screen Recording 2025-06-11 at 7 29 44 PM](https://github.com/user-attachments/assets/b24d580d-ab57-46a1-884d-551d4025d863)




