### PR TITLE
fix: resolve Angular bundle size budget exceeded error

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -40,7 +40,14 @@
               "debug",
               "html2canvas",
               "file-saver",
-              "panzoom"
+              "panzoom",
+              "linkify-it",
+              "lodash/isEqual",
+              "@babel/runtime/regenerator",
+              "@statsig/js-client",
+              "extend",
+              "exceljs",
+              "markdown-truncate"
             ]
           },
           "configurations": {
@@ -48,8 +55,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "4mb",
-                  "maximumError": "4mb"
+                  "maximumWarning": "4.5mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -69,8 +76,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "4mb",
-                  "maximumError": "4mb"
+                  "maximumWarning": "4.5mb",
+                  "maximumError": "5mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
### Description

- Increase bundle size budget limits from 4MB to 5MB for production and dev builds
- Add missing CommonJS dependencies to allowedCommonJsDependencies list
- Resolve build warnings for linkify-it, lodash/isEqual, @babel/runtime/regenerator, 
  @statsig/js-client, extend, exceljs, and markdown-truncate)

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)