### PR TITLE
fix: preserve tables and links when updating editor content via AI

### DIFF
--- a/electron/prompts/context/editor-instructions.ts
+++ b/electron/prompts/context/editor-instructions.ts
@@ -1,0 +1,11 @@
+export const CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS = 
+`CRITICAL INSTRUCTIONS FOR TABLES AND LINKS:
+(!) If any tables or links are present in the description, acceptance criteria, or any input content, you MUST preserve them EXACTLY as they are.
+(!) DO NOT modify, reformat, or alter any table structure (including | symbols, headers, rows, columns).
+(!) DO NOT modify any links (including URLs, markdown links [text](url), or any link formats).
+(!) These elements will be updated manually by humans later - your role is to preserve them unchanged.
+(!) This is a STRICT requirement - any alteration of tables or links is prohibited.
+`
+
+export const SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS = 
+`PRESERVE ALL TABLES AND LINKS UNCHANGED - this overrides any other formatting rules.`

--- a/electron/prompts/feature/story/update.ts
+++ b/electron/prompts/feature/story/update.ts
@@ -1,4 +1,6 @@
+import { CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../../context/editor-instructions';
 import { MARKDOWN_RULES } from '../../context/markdown-rules';
+import { SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../../context/editor-instructions';
 
 export interface UpdateStoryPromptParams {
   name: string;
@@ -47,6 +49,8 @@ Ensure that the revised feature is clear, concise, comprehensive, and actionable
 
 The updated feature must strictly adhere to the client's request and the provided file content, with no additional or irrelevant information included. However, you must always enhance the content to ensure it is actionable, user-centric, and aligned with best practices.
 
+${CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
+
 STRICT:
 (!) Output Structure must be a valid JSON. Follow this exact structure without any modifications:
 
@@ -77,6 +81,7 @@ Special Instructions:
    - I want to have a centralized dashboard for managing user accounts.
 6. You are allowed to use Markdown for the description of the feature. You MUST ONLY use valid Markdown according to the following rules:
     ${MARKDOWN_RULES}
+7. ${SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
 
 STRICT:
 (!) Return a list of features ONLY: no headers, footers, or additional text.

--- a/electron/prompts/feature/task/update.ts
+++ b/electron/prompts/feature/task/update.ts
@@ -1,4 +1,6 @@
+import { CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../../context/editor-instructions';
 import { MARKDOWN_RULES } from '../../context/markdown-rules';
+import { SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../../context/editor-instructions';
 
 export interface UpdateTaskPromptParams {
   name: string;
@@ -41,6 +43,8 @@ The task should be strictly derived from the provided user story description and
 The "Client Request - Task Description" can be expanded to derive acceptance criteria based on provided input but DO NOT include additional or irrelevant content.
 An apt task name should be generated based on the updated acceptance criteria.
 
+${CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
+
 STRICT:
 (!) Ensure to categorize the task as frontend, backend, API integration, UX screens, Infra changes if applicable.
 (!) Output Structure should be a valid JSON: Here is the sample Structure. Follow this exactly. Don't add or change the response JSON
@@ -60,6 +64,7 @@ Special Instructions:
 2. Strictly return ONLY ONE OBJECT in the response tasks array.
 3. You are allowed to use Markdown for the description of the task. You MUST ONLY use valid Markdown according to the following rules:
     ${MARKDOWN_RULES}
+4. ${SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
 
 STRICT:
 (!) return a list of task ONLY: no other headers, footers, or additional text

--- a/electron/prompts/requirement/business-process/add.ts
+++ b/electron/prompts/requirement/business-process/add.ts
@@ -1,3 +1,6 @@
+import { SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from "../../context/editor-instructions";
+import { CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from "../../context/editor-instructions";
+
 interface AddBusinessProcessPromptParams {
   name: string;
   description: string;
@@ -42,6 +45,8 @@ Provide the Business Process Flow that effectively addresses both the client's r
 final_business_process_flow must be a single paragraph, not a list or json format.
 Generate an apt title for final_business_process_flow. Title should be a one-liner not more than 5 words.
 
+${CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
+
 STRICT: 
 (!) The business process flow MUST be based primarily on the client request description.
 (!) Every sentence in the response MUST describe a distinct STEP/ ACTION within the business process flow.
@@ -55,6 +60,7 @@ STRICT:
 (!) Ensure each step in the generated business process is directly and demonstrably related to fulfilling the actions described in the Client Request. Eliminate any steps that are generic, implied from the app description, product requirements, business requirements or not directly contributing to the Client Request's objective.
 (!) Focus description ONLY on PROCESS FLOW: actions and data. EXCLUDE application properties.
 (!) You are allowed to use Markdown for the requirement of the business process.
+(!) ${SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
 
 Output Structure should be a valid JSON: Here is the sample Structure. Follow this exactly. Don't add or change the response JSON:
 

--- a/electron/prompts/requirement/business-process/update.ts
+++ b/electron/prompts/requirement/business-process/update.ts
@@ -1,3 +1,6 @@
+import { SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from "../../context/editor-instructions";
+import { CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from "../../context/editor-instructions";
+
 interface UpdateBusinessProcessPromptParams {
   name: string;
   description: string;
@@ -47,6 +50,8 @@ Update the existing Business Process Flow that effectively addresses both the cl
 final_business_process_flow must be a single paragraph, not a list or json format.
 Generate an apt title for final_business_process_flow. Title should be an one-liner not more than 5 words.
 
+${CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
+
 STRICT: 
 (!) The business process flow MUST be based primarily on the client request description.
 (!) Every sentence in the response MUST describe a distinct STEP/ ACTION within the business process flow.
@@ -60,6 +65,7 @@ STRICT:
 (!) Ensure each step in the generated business process is directly and demonstrably related to fulfilling the actions described in the Client Request. Eliminate any steps that are generic, implied from the app description, or not directly contributing to the Client Request's objective.
 (!) Focus description ONLY on PROCESS FLOW: actions and data. EXCLUDE application properties.
 (!) You are allowed to use Markdown for the requirement of the final business process flow.
+(!) ${SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
 
 Output Structure should be a valid JSON: Here is the sample Structure:
 

--- a/electron/prompts/requirement/update.ts
+++ b/electron/prompts/requirement/update.ts
@@ -1,5 +1,7 @@
 import { MARKDOWN_RULES } from '../context/markdown-rules';
 import { getContextAndType } from '../../utils/get-context';
+import { CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../context/editor-instructions';
+import { SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS } from '../context/editor-instructions';
 
 interface UpdateRequirementParams {
   name: string;
@@ -54,11 +56,14 @@ Output Structure MUST be a valid JSON: Here is the sample Structure:
   "updated": ${format}
 }
 
+${CRITICAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
+
 Special Instructions:
 (!) You are allowed to use Markdown for the updated requirement description. You MUST ONLY use valid Markdown according to the following rules:
 ${MARKDOWN_RULES}
 (!) The output MUST be a valid JSON object strictly adhering to the structure defined above. Failure to produce valid JSON will cause a critical application error.
     The value of the updated key MUST represent one requirement (and absolutely NOT an array of requirements)
+(!) ${SPECIAL_EDITOR_TABLES_AND_LINKS_INSTRUCTIONS}
 
 Output only valid JSON. Do not include \`\`\`json \`\`\` on start and end of the response.`;
 }


### PR DESCRIPTION
### Description

- Updated prompt logic to retain tables and links when AI modifies editor content.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)

### Screenshots

![image](https://github.com/user-attachments/assets/f38f82b5-5e20-439e-9d6c-bc0df3bc1da2)

![image](https://github.com/user-attachments/assets/be79c044-7427-45c6-ab28-3aa278ea6466)





