### PR TITLE
fix: LLM configuration was undefined,causing runtime errors when the app tried to access its properties when moving from version 1.x to 2.x

### DIFF
--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -21,6 +21,7 @@ import { geoAzimuthalEquidistantRaw } from 'd3';
 import { ANALYTICS_TOGGLE_KEY } from './services/analytics/utils/analytics.utils';
 import { APP_CONSTANTS } from './constants/app.constants';
 import { WorkflowProgressService } from './services/workflow-progress/workflow-progress.service';
+import { LLMConfigSchema } from './model/schemas/llm-config.schema';
 
 @Component({
   selector: 'app-root',
@@ -108,12 +109,38 @@ export class AppComponent implements OnInit, OnDestroy {
     this.logger.debug('Initializing LLM configuration');
 
     try {
-      const localConfig =
-        localStorage.getItem('llmConfig') ||
-        (await this.electronService.getStoreValue('llmConfig'));
+      // Handle localStorage (string) and electronService (object) differently
+      const localConfigString = localStorage.getItem('llmConfig');
+      const storeConfigObject = await this.electronService.getStoreValue('llmConfig');
+
+      const localConfig = localConfigString || storeConfigObject;
+
       if (localConfig) {
         try {
-          const config = JSON.parse(localConfig);
+          // Parse only if it's a string, otherwise use the object directly
+          const parsedConfig = typeof localConfig === 'string'
+            ? JSON.parse(localConfig)
+            : localConfig;
+
+          const validationResult = LLMConfigSchema.safeParse(parsedConfig);
+
+          if (!validationResult.success) {
+            this.logger.warn('Invalid LLM configuration format, clearing config:', validationResult.error.issues);
+            localStorage.removeItem('llmConfig');
+            await this.electronService.setStoreValue('llmConfig', null);
+            return;
+          }
+
+          const config = validationResult.data;
+
+          // Ensure the active provider exists in providerConfigs
+          if (!config.providerConfigs[config.activeProvider]) {
+            this.logger.warn('Active provider not found in provider configs, clearing config');
+            localStorage.removeItem('llmConfig');
+            await this.electronService.setStoreValue('llmConfig', null);
+            return;
+          }
+
           const response = await this.electronService.verifyLLMConfig(
             config.activeProvider,
             config.providerConfigs[config.activeProvider].config,
@@ -129,15 +156,34 @@ export class AppComponent implements OnInit, OnDestroy {
           return;
         } catch (e) {
           this.logger.error('Error parsing saved LLM config:', e);
+          localStorage.removeItem('llmConfig');
+          await this.electronService.setStoreValue('llmConfig', null);
         }
       }
 
       const savedConfig = await this.electronService.getStoreValue('llmConfig');
       if (savedConfig) {
-        await this.store.dispatch(new SetLLMConfig(savedConfig)).toPromise();
+        const validationResult = LLMConfigSchema.safeParse(savedConfig);
+
+        if (!validationResult.success) {
+          this.logger.warn('Invalid LLM configuration format in store, clearing config:', validationResult.error.issues);
+          await this.electronService.setStoreValue('llmConfig', null);
+          return;
+        }
+
+        const config = validationResult.data;
+
+        // Ensure the active provider exists in providerConfigs
+        if (!config.providerConfigs[config.activeProvider]) {
+          this.logger.warn('Active provider not found in provider configs in store, clearing config');
+          await this.electronService.setStoreValue('llmConfig', null);
+          return;
+        }
+
+        await this.store.dispatch(new SetLLMConfig(config)).toPromise();
         const response = await this.electronService.verifyLLMConfig(
-          savedConfig.activeProvider,
-          savedConfig.providerConfigs[savedConfig.activeProvider].config,
+          config.activeProvider,
+          config.providerConfigs[config.activeProvider].config,
         );
         if (response.status === 'success') {
           this.logger.debug('LLM configuration verified successfully');
@@ -151,21 +197,30 @@ export class AppComponent implements OnInit, OnDestroy {
       }
 
       const currentState = this.store.selectSnapshot(LLMConfigState.getConfig);
-      if (currentState?.activeProvider) {
-        const response = await this.electronService.verifyLLMConfig(
-          currentState.activeProvider,
-          currentState.providerConfigs[currentState.activeProvider].config,
-        );
-        if (response.status === 'success') {
-          this.logger.debug('LLM configuration verified successfully');
-        } else {
-          this.logger.error(
-            'LLM configuration verification failed:',
-            response.message,
+      const stateValidation = LLMConfigSchema.safeParse(currentState);
+
+      if (stateValidation.success) {
+        const config = stateValidation.data;
+
+        // Ensure the active provider exists in providerConfigs
+        if (config.providerConfigs[config.activeProvider]) {
+          const response = await this.electronService.verifyLLMConfig(
+            config.activeProvider,
+            config.providerConfigs[config.activeProvider].config,
           );
+          if (response.status === 'success') {
+            this.logger.debug('LLM configuration verified successfully');
+          } else {
+            this.logger.error(
+              'LLM configuration verification failed:',
+              response.message,
+            );
+          }
+        } else {
+          this.logger.debug('Active provider not found in current state provider configs');
         }
       } else {
-        this.logger.debug('No LLM configuration found to verify');
+        this.logger.debug('No valid LLM configuration found to verify');
       }
     } catch (error) {
       this.logger.error('Error initializing LLM configuration:', error);

--- a/ui/src/app/components/settings/settings.component.ts
+++ b/ui/src/app/components/settings/settings.component.ts
@@ -514,7 +514,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   private checkForChanges() {
     const formValue = this.configForm.value;
-    const currentConfig = this.currentLLMConfig?.providerConfigs[this.currentLLMConfig.activeProvider]?.config;
+
+    // Add null checks for currentLLMConfig
+    const activeProvider = this.currentLLMConfig?.activeProvider;
+    const currentConfig = activeProvider && this.currentLLMConfig?.providerConfigs?.[activeProvider]?.config;
 
     // Compare provider
     const hasProviderChanged = formValue.provider !== this.initialProvider;

--- a/ui/src/app/model/schemas/llm-config.schema.ts
+++ b/ui/src/app/model/schemas/llm-config.schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const ProviderConfigSchema = z.object({
+  config: z.object({
+    apiKey: z.string().optional(),
+    endpoint: z.string().optional(),
+    deployment: z.string().optional(),
+    accessKeyId: z.string().optional(),
+    secretAccessKey: z.string().optional(),
+    sessionToken: z.string().optional(),
+    region: z.string().optional(),
+    crossRegion: z.boolean().optional(),
+    baseUrl: z.string().optional(),
+    maxRetries: z.number().optional(),
+    model: z.string().optional(),
+  }).passthrough()
+});
+
+export const LLMConfigSchema = z.object({
+  activeProvider: z.string(),
+  providerConfigs: z.record(ProviderConfigSchema),
+  isDefault: z.boolean()
+});
+
+export type LLMConfigSchemaType = z.infer<typeof LLMConfigSchema>;
+export type ProviderConfigSchemaType = z.infer<typeof ProviderConfigSchema>;


### PR DESCRIPTION
### Description

- Added Zod schema validation for LLM configuration and implemented cleanup of invalid data from localStorage and the Electron store when error is thrown
- Updated the Settings page with null checks for currentLLMConfig to ensure stable updates and prevent runtime errors.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)
