### PR TITLE
fix: replaced subTaskTicketId with pmoId in JIRA integration

### DIFF
--- a/ui/src/app/integrations/jira/jira.service.ts
+++ b/ui/src/app/integrations/jira/jira.service.ts
@@ -195,8 +195,8 @@ export class JiraService {
     task: any,
     token: string,
   ): Observable<any> {
-    if (task.subTaskTicketId) {
-      const issueUrl = `${payload.jiraUrl}/rest/api/3/issue/${task.subTaskTicketId}`;
+    if (task.pmoId) {
+      const issueUrl = `${payload.jiraUrl}/rest/api/3/issue/${task.pmoId}`;
       return this.http.get(issueUrl, { headers: this.getHeaders(token) }).pipe(
         switchMap((issue: any) => {
           return convertMarkdownToADF(task.acceptance).pipe(
@@ -261,7 +261,7 @@ export class JiraService {
     token: string,
     adfContent: any,
   ): Observable<any> {
-    const issueUrl = `${payload.jiraUrl}/rest/api/3/issue/${task.subTaskTicketId}?returnIssue=true`;
+    const issueUrl = `${payload.jiraUrl}/rest/api/3/issue/${task.pmoId}?returnIssue=true`;
     const updateData = {
       fields: {
         summary: task.list,
@@ -313,7 +313,7 @@ export class JiraService {
                             map((subTask: any) => {
                               storyDetails.tasks.push({
                                 subTaskName: task.list,
-                                subTaskTicketId: subTask.key,
+                                pmoId: subTask.key,
                               });
                             }),
                           ),
@@ -446,7 +446,7 @@ export class JiraService {
                   // Update existing tasks with JIRA data
                   storyData.data.tasks = storyData.data.tasks.map((existingTask: any) => {
                     const matchingSubTask = subTasks.find(st =>
-                      st && st.subTaskTicketId === existingTask.subTaskTicketId
+                      st && st.pmoId === existingTask.pmoId
                     );
 
                     if (matchingSubTask) {
@@ -484,7 +484,7 @@ export class JiraService {
       switchMap((task: any) => {
         return convertADFToMarkdown(task.fields.description).pipe(
           map((markdownDescription) => ({
-            subTaskTicketId: task.key,
+            pmoId: task.key,
             summary: task.fields.summary,
             description: markdownDescription,
             status: task.fields.status.name,

--- a/ui/src/app/model/interfaces/Jira.ts
+++ b/ui/src/app/model/interfaces/Jira.ts
@@ -17,7 +17,7 @@ export interface RequestFeature {
 
 export interface RequestTask {
   id: string;
-  subTaskTicketId: string;
+  pmoId: string;
   list: string;
   acceptance: string | string[];
 }
@@ -42,7 +42,7 @@ export interface ResponseFeature {
 
 export interface ResponseTask {
   subTaskName: string;
-  subTaskTicketId: string;
+  pmoId: string;
 }
 
 


### PR DESCRIPTION
### Description

-   This fix resolves task-related functionality issues in the JIRA integration, where operations were failing due to
  Incorrect field references.

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)
