### PR TITLE
fix: resolve pagination and ID duplication in PMO integrations

### DIFF
--- a/.changeset/heavy-impalas-add.md
+++ b/.changeset/heavy-impalas-add.md
@@ -1,0 +1,5 @@
+---
+"specif-ai": patch
+---
+
+fix: resolve pagination and ID duplication in PMO integrations

--- a/ui/src/app/components/pmo-integration-modal/pmo-integration-modal.component.ts
+++ b/ui/src/app/components/pmo-integration-modal/pmo-integration-modal.component.ts
@@ -184,10 +184,8 @@ export class PmoIntegrationModalComponent implements OnInit {
     try {
       this.isLoadingWorkItems.set(true);
       const skip = this.currentPage() * this.pageSize();
-      const {tickets: prdsHierarchy, totalCount } = await this.pmoService.getWorkPlanItemsHierarchy(
-        skip,
-        this.pageSize(),
-      );
+      const { tickets: prdsHierarchy, totalCount } =
+        await this.pmoService.getWorkPlanItemsHierarchy(skip, this.pageSize());
 
       if (reset) {
         this.currentPage.set(0);
@@ -202,8 +200,8 @@ export class PmoIntegrationModalComponent implements OnInit {
         this.prdsWithChildren.set([...currentPrds, ...prdsHierarchy]);
       }
 
-      const loadedCount = (this.currentPage() + 1) * this.pageSize();
-      this.hasMoreItems.set(loadedCount < this.totalItems());
+      const actualLoadedCount = this.prdsWithChildren().length;
+      this.hasMoreItems.set(actualLoadedCount < this.totalItems());
 
       // Expand all PRDs and user stories by default
       this.expandAllItemsByDefault(prdsHierarchy);


### PR DESCRIPTION
### Description

Fixes two issues in PMO integration services:

1. **Pagination bug**: `hasMoreItems` calculation used page count instead of actual item count, causing incomplete imports
2. **ID duplication**: User story and task IDs reset per PRD instead of incrementing globally

**Root cause**: ID counters were scoped per-PRD processing loop instead of globally across all imports.

**Solution**: 
- Move ID counter initialization outside PRD loop
- Updated `formatFeaturesForPrd()` method with global counter parameters
- Fix pagination logic to track actual vs total items

closes #360 

### Type of Change

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)