### PR TITLE
fix: Fix UI dropdown overlap and update button state management issues

### DIFF
--- a/ui/src/app/components/core/app-select/app-select.component.ts
+++ b/ui/src/app/components/core/app-select/app-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, forwardRef, HostListener } from '@angular/core';
+import { Component, Input, Output, EventEmitter, forwardRef, HostListener, ElementRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NgClass, NgForOf, NgIf } from '@angular/common';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
@@ -50,12 +50,15 @@ export class AppSelectComponent implements ControlValueAccessor {
   @HostListener('document:click', ['$event'])
   onClick(event: MouseEvent) {
     const target = event.target as HTMLElement;
-    if (!target.closest('.custom-select-container')) {
+    const clickedContainer = target.closest('.custom-select-container');
+    const thisContainer = this.elementRef.nativeElement.querySelector('.custom-select-container');
+    
+    if (!clickedContainer || (clickedContainer && clickedContainer !== thisContainer)) {
       this.showDropdown = false;
     }
   }
 
-  constructor() {
+  constructor(private elementRef: ElementRef) {
     this.filteredOptions = this.options;
   }
 

--- a/ui/src/app/pages/business-process/business-process.component.html
+++ b/ui/src/app/pages/business-process/business-process.component.html
@@ -171,7 +171,7 @@
             rounded="md"
             *ngIf="mode === 'edit'"
             (click)="updateBusinessProcess()"
-            [disabled]="checkFormValidity()"
+            [disabled]="isUpdateDisabled()"
           />
           <app-button
             buttonContent="Add"

--- a/ui/src/app/pages/business-process/business-process.component.ts
+++ b/ui/src/app/pages/business-process/business-process.component.ts
@@ -672,8 +672,10 @@ export class BusinessProcessComponent implements OnInit {
     );
   }
 
-  canDeactivate(): boolean {
-    // Check form changes
+  hasFormChanges(): boolean {
+    if (this.mode === 'add') {
+      return false;
+    }
     const hasFormChanges = this.businessProcessForm.dirty && this.businessProcessForm.touched;
 
     // Compare original vs current PRD selections
@@ -682,7 +684,14 @@ export class BusinessProcessComponent implements OnInit {
     // Compare original vs current BRD selections
     const hasBRDChanges = !this.areSelectionsEqual(this.originalSelectedBRDs, this.selectedBRDs);
 
-    // Return true to allow navigation only if there are no changes or force redirect is allowed
-    return !this.allowForceRedirect && (hasFormChanges || hasPRDChanges || hasBRDChanges);
+    return hasFormChanges || hasPRDChanges || hasBRDChanges;
+  }
+
+  isUpdateDisabled(): boolean {
+    return this.checkFormValidity() || !this.hasFormChanges();
+  }
+
+  canDeactivate(): boolean {
+    return !this.allowForceRedirect && this.hasFormChanges();
   }
 }

--- a/ui/src/app/pages/edit-solution/edit-solution.component.html
+++ b/ui/src/app/pages/edit-solution/edit-solution.component.html
@@ -165,7 +165,7 @@
             rounded="md"
             *ngIf="mode === 'edit'"
             type="submit"
-            [disabled]="requirementForm.invalid"
+            [disabled]="isUpdateDisabled()"
           />
           <app-button
             buttonContent="Add"

--- a/ui/src/app/pages/edit-solution/edit-solution.component.ts
+++ b/ui/src/app/pages/edit-solution/edit-solution.component.ts
@@ -801,6 +801,19 @@ export class EditSolutionComponent {
     return false;
   }
 
+  hasFormChanges(): boolean {
+    if (this.mode === 'add') {
+      return false;
+    }
+    const hasBasicChanges = this.requirementForm.dirty && this.requirementForm.touched;
+    const hasMappingChanges = this.checkMappingChanges();
+    return hasBasicChanges || hasMappingChanges;
+  }
+
+  isUpdateDisabled(): boolean {
+    return this.requirementForm.invalid || !this.hasFormChanges();
+  }
+
   extractPropertyValues<
     TData extends Array<TDataItem>,
     TDataItem extends Record<string, any>,

--- a/ui/src/app/pages/edit-user-stories/edit-user-stories.component.html
+++ b/ui/src/app/pages/edit-user-stories/edit-user-stories.component.html
@@ -112,7 +112,7 @@
             rounded="md"
             *ngIf="mode === 'edit'"
             type="submit"
-            [disabled]="userStoryForm.invalid"
+            [disabled]="isUpdateDisabled()"
           />
           <app-button
             buttonContent="Add"

--- a/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
+++ b/ui/src/app/pages/edit-user-stories/edit-user-stories.component.ts
@@ -466,6 +466,17 @@ export class EditUserStoriesComponent implements OnDestroy {
     this.uploadedFileContent = content;
   }
 
+  hasFormChanges(): boolean {
+    if (this.mode === 'add') {
+      return false;
+    }
+    return this.userStoryForm.dirty && this.userStoryForm.touched;
+  }
+
+  isUpdateDisabled(): boolean {
+    return this.userStoryForm.invalid || !this.hasFormChanges();
+  }
+
   canDeactivate(): boolean {
     return (
       !this.allowForceRedirect &&

--- a/ui/src/app/pages/tasks/add-task/add-task.component.html
+++ b/ui/src/app/pages/tasks/add-task/add-task.component.html
@@ -109,7 +109,7 @@
             rounded="md"
             *ngIf="mode === 'edit'"
             type="submit"
-            [disabled]="taskForm.invalid"
+            [disabled]="isUpdateDisabled()"
           />
           <app-button
             buttonContent="Add"

--- a/ui/src/app/pages/tasks/add-task/add-task.component.ts
+++ b/ui/src/app/pages/tasks/add-task/add-task.component.ts
@@ -506,6 +506,17 @@ export class AddTaskComponent implements OnDestroy {
     this.destroy$.complete();
   }
 
+  hasFormChanges(): boolean {
+    if (this.mode === 'add') {
+      return false;
+    }
+    return this.taskForm.dirty && this.taskForm.touched;
+  }
+
+  isUpdateDisabled(): boolean {
+    return this.taskForm.invalid || !this.hasFormChanges();
+  }
+
   canDeactivate(): boolean {
     return (
       !this.allowForceRedirect &&


### PR DESCRIPTION
## Description
This PR addresses two UI/UX issues in the application:

**Issue 1 - Dropdown Overlap Fix:**
Fixed an issue where the Model dropdown remained visible when opening the LLM Provider dropdown, causing UI overlap and hiding provider data. The Model dropdown now properly closes when the LLM Provider dropdown is opened, ensuring proper visibility of all options.

**Issue 2 - Update Button State Management:**
Fixed improper update button behavior where users could successfully "update" entities (BRD, PRD, User Story, Task, Business Process) without making any changes. The update button is now properly disabled when no modifications are made, and unnecessary confirmation dialogs have been removed for BRD entities.

**Changes Made:**
- Implemented proper dropdown state management in LLM configuration settings
- Added change detection to enable/disable update button based on form state
- Removed confirmation dialog for BRD entities as per requirements
- Update button now only enables when actual modifications are detected

Closes: #254 
Closes: #142 

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## Pre-flight Checklist
- [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
- [x] I have reviewed [[contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)