### PR TITLE
feat: add GPT-5.2 support

### DIFF
--- a/electron/services/llm/langchain-providers/openai.ts
+++ b/electron/services/llm/langchain-providers/openai.ts
@@ -7,6 +7,7 @@ import { guardrailsEngine } from '../../../guardrails';
 export enum OpenAiModelId {
   O3 = 'o3',
   O4_MINI = 'o4-mini',
+  GPT_5_2 = 'gpt-5.2',
   GPT_4_1 = 'gpt-4.1',
   GPT_4_1_MINI = 'gpt-4.1-mini',
   GPT_4_1_NANO = 'gpt-4.1-nano',
@@ -28,6 +29,10 @@ const OpenAiModels: Record<OpenAiModelId, ModelInfoV1> = {
   [OpenAiModelId.O4_MINI]: {
     maxTokens: 100_000,
     contextWindow: 200_000,
+  },
+  [OpenAiModelId.GPT_5_2]: {
+    maxTokens: 16_384,
+    contextWindow: 128_000,
   },
   [OpenAiModelId.GPT_4_1]: {
     maxTokens: 32_768,
@@ -75,6 +80,16 @@ const OpenAiModels: Record<OpenAiModelId, ModelInfoV1> = {
   },
 };
 
+function getOpenAiModelInfo(model: string): ModelInfoV1 {
+  const modelInfo = OpenAiModels[model as OpenAiModelId];
+
+  if (!modelInfo) {
+    throw new LLMError(`Unsupported OpenAI model: ${model}`, 'openai');
+  }
+
+  return modelInfo;
+}
+
 interface OpenAIConfig extends LLMConfig {
   baseUrl?: string;
   apiKey: string;
@@ -88,7 +103,7 @@ export class OpenAILangChainProvider implements LangChainModelProvider {
 
   constructor(config: Partial<OpenAIConfig>) {
     this.configData = this.getConfig(config);
-    const modelInfo = OpenAiModels[this.configData.model];
+    const modelInfo = getOpenAiModelInfo(this.configData.model);
 
     this.model = LangChainChatGuardrails(
       new ChatOpenAI({
@@ -112,10 +127,12 @@ export class OpenAILangChainProvider implements LangChainModelProvider {
       throw new LLMError('Model ID is required', 'openai');
     }
 
+    getOpenAiModelInfo(config.model);
+
     return {
       baseUrl: config.baseUrl,
       apiKey: config.apiKey,
-      model: config.model,
+      model: config.model as OpenAiModelId,
       maxRetries: config.maxRetries || 3,
     };
   }
@@ -125,7 +142,7 @@ export class OpenAILangChainProvider implements LangChainModelProvider {
   }
 
   getModel() {
-    const modelInfo = OpenAiModels[this.configData.model];
+    const modelInfo = getOpenAiModelInfo(this.configData.model);
 
     return {
       id: this.configData.model,

--- a/ui/src/app/constants/llm.models.constants.spec.ts
+++ b/ui/src/app/constants/llm.models.constants.spec.ts
@@ -1,0 +1,9 @@
+import { getProviderModels } from './llm.models.constants';
+
+describe('getProviderModels', () => {
+  it('includes GPT-5.2 for OpenAI Native', async () => {
+    const models = await getProviderModels('openai-native');
+
+    expect(models).toContain('gpt-5.2');
+  });
+});

--- a/ui/src/app/constants/llm.models.constants.ts
+++ b/ui/src/app/constants/llm.models.constants.ts
@@ -28,7 +28,7 @@ export async function getProviderModels(provider: string): Promise<string[]> {
   }
 
   const modelMap: { [key: string]: string[] } = {
-    'openai-native': ['gpt-4o', 'gpt-4o-mini'],
+    'openai-native': ['gpt-4o', 'gpt-4o-mini', 'gpt-5.2'],
     'bedrock': [
       'anthropic.claude-opus-4-20250514-v1:0',
       'anthropic.claude-sonnet-4-20250514-v1:0',


### PR DESCRIPTION
## Summary
- add `gpt-5.2` to the OpenAI Native model list in the UI
- wire `gpt-5.2` into the Electron OpenAI LangChain provider metadata
- validate OpenAI model IDs through a shared helper and add a focused UI spec

## Validation
- `cd electron && npm run check`
- `cd ui && ./node_modules/.bin/tsc --noEmit --target es2022 --module es2022 --moduleResolution node --lib es2022,dom --types jasmine src/app/constants/llm.models.constants.ts src/app/constants/llm.models.constants.spec.ts`
- `cd ui && npm test -- --watch=false --browsers=ChromeHeadless --include src/app/constants/llm.models.constants.spec.ts` *(blocked by unrelated pre-existing spec compile errors in the repo, e.g. `breadcrumb.state.spec.ts` and `user-stories.state.spec.ts`)*

## Notes
- I used conservative metadata for `gpt-5.2` (`maxTokens: 16384`, `contextWindow: 128000`) to match the request without broadening unrelated behavior.
